### PR TITLE
[fix/lectures_urls] lectures urls에 슬래시 추가

### DIFF
--- a/apps/lectures/urls/crawled_lecture_url.py
+++ b/apps/lectures/urls/crawled_lecture_url.py
@@ -3,5 +3,5 @@ from django.urls import path
 from apps.lectures.views.crawled_lecture_view import CrawledLectureListAPIView
 
 urlpatterns = [
-    path("lectures", CrawledLectureListAPIView.as_view(), name="lectures"),
+    path("/lectures", CrawledLectureListAPIView.as_view(), name="lectures"),
 ]


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: lectures url] 앞에 슬래시 추가

## 📄 상세 내용
- [x] swagger ui에서 url이 정상적으로 노출되지 않아
이를 정상적으로 보이게 하기 위해 lectures 앱 내의 urls에서  "lectures" -> "/lectures" 로 변경

## 📸 스크린샷
## 변경전
<img width="1636" height="362" alt="image" src="https://github.com/user-attachments/assets/22f45588-445c-421b-8b4c-3f7aa2018753" />

## 변경후
<img width="1597" height="255" alt="image" src="https://github.com/user-attachments/assets/ce394ce7-efc0-45b7-9f02-a2f8781809e0" />

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
