### PR TITLE
[Feat/application admin] Admin Application 관련 serializer 작성

### DIFF
--- a/apps/application/serializers/admin_application_serializers.py
+++ b/apps/application/serializers/admin_application_serializers.py
@@ -8,8 +8,10 @@ from apps.users.models import User
 
 DATE_TIME_FORMAT = "%Y-%m-%d %H:%M"
 
+
 class AppliedAtSerializerMixin:
     applied_at = serializers.DateTimeField(source="created_at", format=DATE_TIME_FORMAT, read_only=True)
+
 
 class AdminApplicantSummarySerializer(serializers.ModelSerializer["User"]):
     """(Admin) 지원자 요약 정보"""
@@ -29,11 +31,10 @@ class AdminRecruitmentSummarySerializer(serializers.ModelSerializer["Recruitment
         read_only_fields = ["id", "uuid", "title"]
 
 
-
 class AdminApplicationListSerializer(AppliedAtSerializerMixin, serializers.ModelSerializer["Application"]):
     """(Admin Page) 지원서 목록 조회"""
 
-    id = serializers.IntegerField(read_only=True) 
+    id = serializers.IntegerField(read_only=True)
     recruitment = AdminRecruitmentSummarySerializer(read_only=True)
     applicant = AdminApplicantSummarySerializer(read_only=True)
     updated_at = serializers.DateTimeField(format=DATE_TIME_FORMAT, read_only=True)

--- a/apps/application/serializers/admin_application_serializers.py
+++ b/apps/application/serializers/admin_application_serializers.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from rest_framework import serializers
+
+from apps.application.models import Application
+from apps.recruitment.models import Recruitment
+from apps.users.models import User
+
+DATE_TIME_FORMAT = "%Y-%m-%d %H:%M"
+
+class AppliedAtSerializerMixin:
+    applied_at = serializers.DateTimeField(source="created_at", format=DATE_TIME_FORMAT, read_only=True)
+
+class AdminApplicantSummarySerializer(serializers.ModelSerializer["User"]):
+    """(Admin) 지원자 요약 정보"""
+
+    class Meta:
+        model = User
+        fields = ["id", "nickname", "email", "profile_img_url"]
+        read_only_fields = ["id", "nickname", "email", "profile_img_url"]
+
+
+class AdminRecruitmentSummarySerializer(serializers.ModelSerializer["Recruitment"]):
+    """(Admin) 공고 요약 정보"""
+
+    class Meta:
+        model = Recruitment
+        fields = ["id", "uuid", "title"]
+        read_only_fields = ["id", "uuid", "title"]
+
+
+
+class AdminApplicationListSerializer(AppliedAtSerializerMixin, serializers.ModelSerializer["Application"]):
+    """(Admin Page) 지원서 목록 조회"""
+
+    id = serializers.IntegerField(read_only=True) 
+    recruitment = AdminRecruitmentSummarySerializer(read_only=True)
+    applicant = AdminApplicantSummarySerializer(read_only=True)
+    updated_at = serializers.DateTimeField(format=DATE_TIME_FORMAT, read_only=True)
+
+    class Meta:
+        model = Application
+        fields = [
+            "id",
+            "uuid",
+            "recruitment",
+            "applicant",
+            "status",
+            "applied_at",
+            "updated_at",
+        ]
+        read_only_fields = [
+            "id",
+            "uuid",
+            "recruitment",
+            "applicant",
+            "status",
+            "applied_at",
+            "updated_at",
+        ]
+
+
+class AdminApplicationDetailSerializer(AppliedAtSerializerMixin, serializers.ModelSerializer["Application"]):
+    """(Admin Page) 지원서 상세 조회"""
+
+    id = serializers.IntegerField(read_only=True)
+    recruitment = AdminRecruitmentSummarySerializer(read_only=True)
+    applicant = AdminApplicantSummarySerializer(read_only=True)
+    updated_at = serializers.DateTimeField(format=DATE_TIME_FORMAT, read_only=True)
+
+    class Meta:
+        model = Application
+        fields = [
+            "id",
+            "uuid",
+            "applicant",
+            "recruitment",
+            "self_introduction",
+            "motivation",
+            "objective",
+            "available_time",
+            "has_study_experience",
+            "study_experience",
+            "status",
+            "applied_at",
+            "updated_at",
+        ]
+        read_only_fields = [
+            "id",
+            "uuid",
+            "applicant",
+            "recruitment",
+            "self_introduction",
+            "motivation",
+            "objective",
+            "available_time",
+            "has_study_experience",
+            "study_experience",
+            "status",
+            "applied_at",
+            "updated_at",
+        ]

--- a/apps/application/serializers/application_serializers.py
+++ b/apps/application/serializers/application_serializers.py
@@ -139,7 +139,7 @@ class RecruiterApplicationDetailSerializer(ApplicationCommonFieldsMixin, Applica
 class ApplicantApplicationListSerializer(ApplicationCommonFieldsMixin):
     """REQ-APLY-006: 내가 지원한 목록"""
 
-    recruitment = RecruitmentSummarySerializer(read_only=True)  # ★ 이름 변경 적용
+    recruitment = RecruitmentSummarySerializer(read_only=True)
 
     class Meta(ApplicationCommonFieldsMixin.Meta):
         fields = ApplicationCommonFieldsMixin.Meta.fields + ["recruitment"]

--- a/apps/application/serializers/application_serializers.py
+++ b/apps/application/serializers/application_serializers.py
@@ -16,7 +16,40 @@ class AppliedAtSerializerMixin:
     applied_at = serializers.DateTimeField(source="created_at", format=DATE_TIME_FORMAT, read_only=True)
 
 
-class ApplicantSerializer(serializers.ModelSerializer["User"]):
+class ApplicationCommonFieldsMixin(AppliedAtSerializerMixin, serializers.ModelSerializer["Application"]):
+    """모든 List/Detail 조회에 공통으로 포함되는 필드 정의"""
+
+    uuid = serializers.UUIDField(read_only=True)
+    status = serializers.CharField(read_only=True)
+    updated_at = serializers.DateTimeField(format=DATE_TIME_FORMAT, read_only=True)
+
+    class Meta:
+        model = Application
+        fields = ["uuid", "status", "applied_at", "updated_at"]
+        read_only_fields = ["uuid", "status", "applied_at", "updated_at"]
+
+
+class ApplicationDetailFieldsMixin:
+    """모든 상세 조회에 공통으로 포함되는 지원서 상세 내용 필드"""
+
+    self_introduction = serializers.CharField(read_only=True)
+    motivation = serializers.CharField(read_only=True)
+    objective = serializers.CharField(read_only=True)
+    available_time = serializers.CharField(read_only=True)
+    has_study_experience = serializers.BooleanField(read_only=True)
+    study_experience = serializers.CharField(read_only=True)
+
+    DETAIL_FIELDS = [
+        "self_introduction",
+        "motivation",
+        "objective",
+        "available_time",
+        "has_study_experience",
+        "study_experience",
+    ]
+
+
+class ApplicantSummarySerializer(serializers.ModelSerializer["User"]):
     """지원자 요약 정보"""
 
     class Meta:
@@ -25,7 +58,7 @@ class ApplicantSerializer(serializers.ModelSerializer["User"]):
         read_only_fields = ["nickname", "gender", "profile_img_url"]
 
 
-class RecruitmentInfoSerializer(serializers.ModelSerializer["Recruitment"]):
+class RecruitmentSummarySerializer(serializers.ModelSerializer["Recruitment"]):
     """공고 요약 정보"""
 
     class Meta:
@@ -64,97 +97,60 @@ class ApplicationCreateSerializer(serializers.ModelSerializer["Application"]):
         return data
 
 
-class RecruiterApplicationListSerializer(AppliedAtSerializerMixin, serializers.ModelSerializer["Application"]):
+class RecruiterApplicationListSerializer(ApplicationCommonFieldsMixin):
     """REQ-APLY-002: 작성자용 목록 조회"""
 
-    applicant = ApplicantSerializer(read_only=True)
+    applicant = ApplicantSummarySerializer(read_only=True)
+    available_time = serializers.CharField(read_only=True)
+    has_study_experience = serializers.BooleanField(read_only=True)
 
-    class Meta:
-        model = Application
-        fields = [
-            "uuid",
+    class Meta(ApplicationCommonFieldsMixin.Meta):
+        fields = ApplicationCommonFieldsMixin.Meta.fields + ["applicant", "available_time", "has_study_experience"]
+        read_only_fields = ApplicationCommonFieldsMixin.Meta.read_only_fields + [
             "applicant",
             "available_time",
             "has_study_experience",
-            "status",
-            "applied_at",
         ]
-        read_only_fields = ["uuid", "applicant", "available_time", "has_study_experience", "status", "applied_at"]
 
 
-class RecruiterApplicationDetailSerializer(AppliedAtSerializerMixin, serializers.ModelSerializer["Application"]):
+class RecruiterApplicationDetailSerializer(ApplicationCommonFieldsMixin, ApplicationDetailFieldsMixin):
     """REQ-APLY-003: 작성자용 상세 조회"""
 
-    applicant = ApplicantSerializer(read_only=True)
+    applicant = ApplicantSummarySerializer(read_only=True)
 
-    class Meta:
-        model = Application
-        fields = [
-            "uuid",
-            "applicant",
-            "self_introduction",
-            "motivation",
-            "objective",
-            "available_time",
-            "has_study_experience",
-            "study_experience",
-            "status",
-            "applied_at",
-        ]
-        read_only_fields = [
-            "uuid",
-            "applicant",
-            "self_introduction",
-            "motivation",
-            "objective",
-            "available_time",
-            "has_study_experience",
-            "study_experience",
-            "status",
-            "applied_at",
-        ]
+    class Meta(ApplicationCommonFieldsMixin.Meta):
+        fields = (
+            ApplicationCommonFieldsMixin.Meta.fields
+            + [
+                "applicant",
+            ]
+            + ApplicationDetailFieldsMixin.DETAIL_FIELDS
+        )
+
+        read_only_fields = (
+            ApplicationCommonFieldsMixin.Meta.read_only_fields
+            + [
+                "applicant",
+            ]
+            + ApplicationDetailFieldsMixin.DETAIL_FIELDS
+        )
 
 
-class ApplicantApplicationListSerializer(AppliedAtSerializerMixin, serializers.ModelSerializer["Application"]):
+class ApplicantApplicationListSerializer(ApplicationCommonFieldsMixin):
     """REQ-APLY-006: 내가 지원한 목록"""
 
-    recruitment = RecruitmentInfoSerializer(read_only=True)
+    recruitment = RecruitmentSummarySerializer(read_only=True)  # ★ 이름 변경 적용
 
-    class Meta:
-        model = Application
-        fields = [
-            "uuid",
-            "recruitment",
-            "status",
-            "applied_at",
-        ]
-        read_only_fields = ["uuid", "recruitment", "status", "applied_at"]
+    class Meta(ApplicationCommonFieldsMixin.Meta):
+        fields = ApplicationCommonFieldsMixin.Meta.fields + ["recruitment"]
+        read_only_fields = ApplicationCommonFieldsMixin.Meta.read_only_fields + ["recruitment"]
 
 
-class ApplicantApplicationDetailSerializer(AppliedAtSerializerMixin, serializers.ModelSerializer["Application"]):
+class ApplicantApplicationDetailSerializer(ApplicationCommonFieldsMixin, ApplicationDetailFieldsMixin):
     """REQ-APLY-007: 본인 지원 내역 상세"""
 
-    class Meta:
-        model = Application
-        fields = [
-            "uuid",
-            "self_introduction",
-            "motivation",
-            "objective",
-            "available_time",
-            "has_study_experience",
-            "study_experience",
-            "status",
-            "applied_at",
-        ]
-        read_only_fields = [
-            "uuid",
-            "self_introduction",
-            "motivation",
-            "objective",
-            "available_time",
-            "has_study_experience",
-            "study_experience",
-            "status",
-            "applied_at",
-        ]
+    class Meta(ApplicationCommonFieldsMixin.Meta):
+        fields = ApplicationCommonFieldsMixin.Meta.fields + ApplicationDetailFieldsMixin.DETAIL_FIELDS
+        read_only_fields = (
+            ApplicationCommonFieldsMixin.Meta.read_only_fields + ApplicationDetailFieldsMixin.DETAIL_FIELDS
+        )


### PR DESCRIPTION
## ✅ PR 요약
- Admin 페이지에서 지원서 목록 및 상세 조회를 위한 전용 Serializer 구현
- Admin Applicant/Recruitment 분리하여 관리자 전용 필드만 노출할 수 있게 구현

## 📄 상세 내용
- [ ] admin_application_serializers.py 작성

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
