### PR TITLE
[Feat/crawled lecture filter] crawled_lecture 목록 조회 필터 & 정렬 작성 

### DIFF
--- a/apps/lectures/filters/crawled_lecture_filter.py
+++ b/apps/lectures/filters/crawled_lecture_filter.py
@@ -1,0 +1,5 @@
+from django_filters import CharFilter, FilterSet
+
+
+class CrawledLectureFilter(FilterSet):
+    category = CharFilter(field_name="lecture_categories__category__name", lookup_expr="iexact")

--- a/apps/lectures/views/crawled_lecture_view.py
+++ b/apps/lectures/views/crawled_lecture_view.py
@@ -1,12 +1,16 @@
+from typing import cast
+
+from django.conf import settings
 from django.db.models import QuerySet
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import OpenApiParameter, extend_schema
+from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_field
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import AllowAny
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from apps.lectures.filters.crawled_lecture_filter import CrawledLectureFilter
 from apps.lectures.models import CrawledLecture
 from apps.lectures.serializers.crawled_lecture_serializer import (
     CrawledLectureSerializer,
@@ -17,6 +21,35 @@ class CrawledLectureListAPIView(APIView):
     permission_classes = [AllowAny]
     serializer_class = CrawledLectureSerializer
     pagination_class = PageNumberPagination
+    search_fields = ["title", "instructor"]
+    filterset_class = CrawledLectureFilter
+
+    sort_map = {
+        "latest": "-created_at",
+        "oldest": "created_at",
+        "low_price": "discount_price",
+        "high_price": "-discount_price",
+        "high_rating": "-average_rating",
+        "low_rating": "average_rating",
+    }
+
+    @extend_schema_field(dict)
+    def get_queryset(self) -> QuerySet[CrawledLecture]:
+        queryset = CrawledLecture.objects.all()
+
+        filterset = self.filterset_class(data=self.request.GET, queryset=queryset, request=self.request)
+        queryset = cast(QuerySet[CrawledLecture], filterset.qs)
+
+        for field in self.search_fields:
+            search = self.request.GET.get("search")
+            if search:
+                queryset = queryset.filter(**{f"{field}__icontains": search})
+
+        sort_key = self.request.GET.get("sort")
+        if sort_key in self.sort_map:
+            queryset = queryset.order_by(self.sort_map[sort_key])
+
+        return queryset
 
     @extend_schema(
         tags=["lectures"],
@@ -30,45 +63,33 @@ class CrawledLectureListAPIView(APIView):
                 required=False,
             ),
             OpenApiParameter(
-                name="latest",
+                name="search",
                 type=OpenApiTypes.STR,
                 location="query",
-                description="최신순으로 정렬할 때 선택됩니다.",
+                description="강의 제목 또는 강사 이름으로 검색합니다.",
                 required=False,
             ),
             OpenApiParameter(
-                name="oldest",
+                name="sort",
                 type=OpenApiTypes.STR,
                 location="query",
-                description="오래된순으로 정렬할 때 선택됩니다.",
-                required=False,
-            ),
-            OpenApiParameter(
-                name="low_price",
-                type=OpenApiTypes.STR,
-                location="query",
-                description="낮은 가격순으로 정렬할 때 선택됩니다.",
-                required=False,
-            ),
-            OpenApiParameter(
-                name="high_price",
-                type=OpenApiTypes.STR,
-                location="query",
-                description="높은 가격순으로 정렬할 때 선택됩니다.",
-                required=False,
-            ),
-            OpenApiParameter(
-                name="high_rating",
-                type=OpenApiTypes.STR,
-                location="query",
-                description="높은 리뷰 평점순으로 정렬할 때 선택됩니다.",
-                required=False,
-            ),
-            OpenApiParameter(
-                name="low_rating",
-                type=OpenApiTypes.STR,
-                location="query",
-                description="낮은 리뷰 평점순으로 정렬할 때 선택됩니다.",
+                enum=[
+                    "latest",
+                    "oldest",
+                    "low_price",
+                    "high_price",
+                    "high_rating",
+                    "low_rating",
+                ],
+                description="""
+아래의 정렬 기준을 선택할 수 있습니다:
+- latest : 최신순으로 정렬
+- oldest : 오래된순으로 정렬
+- low_price : 낮은 가격순으로 정렬
+- high_price : 높은 가격순으로 정렬
+- high_rating : 높은 리뷰 평점순으로 정렬
+- low_rating : 낮은 리뷰 평점순으로 정렬
+                """,
                 required=False,
             ),
         ],
@@ -98,8 +119,14 @@ class CrawledLectureListAPIView(APIView):
             )
             for i in range(15)
         ]
-
         paginator = self.pagination_class()
-        page: list[CrawledLecture] | None = paginator.paginate_queryset(mock_data, request)  # type: ignore[arg-type]
+        page: list[CrawledLecture] | None
+
+        if settings.DEBUG:
+            page = paginator.paginate_queryset(mock_data, request)  # type: ignore[arg-type]
+        else:
+            queryset = self.get_queryset()
+            page = paginator.paginate_queryset(queryset, request)
+
         serializer = self.serializer_class(page, many=True)
         return paginator.get_paginated_response(serializer.data)


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: crawled_lecture 목록 조회 필터 작성 

## 📄 상세 내용
- [x] crawled_lecture 필터 모듈화
- [x] 강의 목록 조회시 카테고리에 맞는 강의를 필터링하기 위해 필터 파일 작성
- [x] crawled_lecture_view에서 강의명, 강사명으로 검색 적용 및 정렬 적용을 위해 
get_query() 단계에서 필터셋 -> 검색 -> 정렬 순서로 쿼리셋을 거른 후 페이지네이터로 자르고 시리얼라이저에서 직렬화
- [x] 정렬에 대한 문서화를 다듬기 위해 extend_schema 변경 (정렬 구분은 아래 스크린샷으로 첨부)
- [x] 목록 조회 결과 DEBUG 분기 처리 (현재는 develop에서 manage.py가 local.py를 지정중 -> DEBUG truthy -> mock data 출력)

## 📸 스크린샷

## 정렬 구분
<img width="1612" height="881" alt="image" src="https://github.com/user-attachments/assets/efa8ad36-249d-48f0-80ff-0855dcb5e529" />

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
