### PR TITLE
[Feat/exception handeler] 전역 예외 처리 핸들러 작성

### DIFF
--- a/apps/core/exception_handler.py
+++ b/apps/core/exception_handler.py
@@ -1,0 +1,40 @@
+from typing import Any, Type
+
+from django.http import Http404
+from rest_framework import exceptions, status
+from rest_framework.response import Response
+from rest_framework.views import exception_handler
+
+COMMON_EXCEPTION_MESSAGES: dict[Type[BaseException], tuple[str, int]] = {
+    Http404: ("요청한 리소스를 찾을 수 없습니다.", status.HTTP_404_NOT_FOUND),
+    exceptions.PermissionDenied: ("권한이 없습니다.", status.HTTP_403_FORBIDDEN),
+    exceptions.AuthenticationFailed: ("자격 인증 데이터가 제공되지 않았습니다.", status.HTTP_401_UNAUTHORIZED),
+    exceptions.NotAuthenticated: ("인증 정보가 제공되지 않았습니다.", status.HTTP_401_UNAUTHORIZED),
+    exceptions.MethodNotAllowed: ("허용되지 않는 메서드입니다.", status.HTTP_405_METHOD_NOT_ALLOWED),
+}
+
+
+def match_common_exception(exc: Exception) -> Response | None:
+    for exc_type, (msg, code) in COMMON_EXCEPTION_MESSAGES.items():
+        if isinstance(exc, exc_type):
+            return Response({"error_detail": msg}, status=code)
+    return None
+
+
+def custom_exception_handler(exc: Exception, context: dict[str, Any]) -> Response | None:
+    error_keys = ["msg", "message", "error", "detail"]
+
+    if common := match_common_exception(exc):
+        return common
+
+    if not (response := exception_handler(exc, context)):
+        return Response({"error_detail": "서버에서 알 수 없는 오류가 발생했습니다."}, status=500)
+
+    if isinstance(response.data, dict) and (
+        matched_key := next((key for key in error_keys if key in response.data), None)
+    ):
+        response.data = {"error_detail": response.data.pop(matched_key)}
+    else:
+        response.data = {"error_detail": response.data}
+
+    return response

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -178,6 +178,7 @@ REST_FRAMEWORK = {
     "DEFAULT_FILTER_BACKENDS": ("django_filters.rest_framework.DjangoFilterBackend",),
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 10,
+    # 'EXCEPTION_HANDLER': 'apps.core.exception_handler.custom_exception_handler'
 }
 
 # drf-spectacular 관련 설정

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -178,7 +178,7 @@ REST_FRAMEWORK = {
     "DEFAULT_FILTER_BACKENDS": ("django_filters.rest_framework.DjangoFilterBackend",),
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 10,
-    # 'EXCEPTION_HANDLER': 'apps.core.exception_handler.custom_exception_handler'
+    "EXCEPTION_HANDLER": "apps.core.exception_handler.custom_exception_handler",
 }
 
 # drf-spectacular 관련 설정


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 전역 예외 처리 핸들러 작성

## 📄 상세 내용
- [x] 401, 403, 404, 405 공통 예외 처리 작성
- [x] drf에서 해결 할 수 없는 예외는 500 상태코드로 일관되게 응답
- [x] drf에서 detail을 포함하지 않는 기존 dict, list 타입의 예외에 대해서도 error_detail로 감싸서 처리
- [x] 예외 설명이 기존 drf 표준인 detail이 아닌 예외를 처리하기 위해 ["msg", "message", "error", "detail"] 내에서 검사하여 스위칭

## 수정사항
- [x] 주석 해제 완료

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.