### PR TITLE
[feat/chat_services] chatroom_service.py, last_read_service.py 리팩토링 및 기능 개선

### DIFF
--- a/apps/chat/services/chatroom_service.py
+++ b/apps/chat/services/chatroom_service.py
@@ -1,7 +1,10 @@
+from typing import Any, Optional
+
 from django.core.exceptions import PermissionDenied
 from django.db.models import QuerySet
 
 from apps.chat.models.chat_message import ChatMessage
+from apps.chat.services.last_read_service import LastReadService
 from apps.study_groups.models import GroupMember, StudyGroup
 from apps.users.models import User
 
@@ -17,15 +20,105 @@ class ChatRoomService:
         """
         exists = GroupMember.objects.filter(
             study_group_id=study_group.id,
-            user_id=user.id,  # mypy 오류로 user 대신 user.id를 넘겼습니다.
+            user_id=user.id,
         ).exists()
 
-        # 스터디 그룹 비회원이면 채팅방 접근 금지
         if not exists:
             raise PermissionDenied("그룹 멤버만 채팅을 조회할 수 있습니다.")
 
     @staticmethod
-    def get_messages(study_group: StudyGroup) -> QuerySet[ChatMessage]:
-        # 특정 스터디 그룹의 메시지 목록 조회
+    def get_chatrooms(user: User) -> list[dict[str, Any]]:
+        # 채팅방 목록 조회
+        memberships = GroupMember.objects.filter(user_id=user.id).select_related("study_group_id")
 
-        return ChatMessage.objects.filter(study_group=study_group).select_related("sender").order_by("created_at")
+        results: list[dict[str, Any]] = []
+
+        for member in memberships:
+            group = member.study_group_id  # FK 객체
+
+            last_message: Optional[ChatMessage] = (
+                ChatMessage.objects.filter(study_group=group).order_by("-created_at").first()
+            )
+
+            last_read = LastReadService.get_last_read(group, user)
+
+            if last_read:
+                unread_count = ChatMessage.objects.filter(
+                    study_group=group,
+                    created_at__gt=last_read.message.created_at,
+                ).count()
+            else:
+                unread_count = ChatMessage.objects.filter(study_group=group).count()
+
+            results.append(
+                {
+                    "group_id": group.id,
+                    "group_name": group.name,
+                    "last_message_content": last_message.content if last_message else None,
+                    "last_message_time": last_message.created_at if last_message else None,
+                    "unread_count": unread_count,
+                }
+            )
+
+        return results
+
+    @staticmethod
+    def get_room_info(study_group: StudyGroup, user: User) -> dict[str, Any]:
+        # 채팅방 접속 시 필요한 기본 정보 조회
+        ChatRoomService.validate_member(study_group, user)
+
+        members = GroupMember.objects.filter(study_group_id=study_group.id).select_related("user_id")
+
+        member_list = [
+            {
+                "nickname": m.user_id.nickname,
+                "is_leader": m.is_leader,
+            }
+            for m in members
+        ]
+
+        return {
+            "group_id": study_group.id,
+            "group_name": study_group.name,
+            "members": member_list,
+        }
+
+    @staticmethod
+    def get_messages(
+        study_group: StudyGroup,
+        user: User,
+        cursor: Optional[int] = None,
+        limit: int = 300,
+    ) -> QuerySet[ChatMessage]:
+
+        ChatRoomService.validate_member(study_group, user)
+
+        membership = GroupMember.objects.get(
+            study_group_id=study_group.id,
+            user_id=user.id,
+        )
+
+        queryset = ChatMessage.objects.filter(
+            study_group=study_group,
+            # 가입 이후만 보여주기
+            created_at__gte=membership.created_at,
+        ).select_related("sender")
+
+        if cursor:
+            queryset = queryset.filter(id__lte=cursor)
+
+        return queryset.order_by("-id")[:limit]
+
+    @staticmethod
+    def mark_all_read(study_group: StudyGroup, user: User) -> None:
+        # 채팅방 접속시 사용자가 이전에 읽지 않은 메시지를 가장 최신 메시지 기준으로 전부 읽음 처리
+        ChatRoomService.validate_member(study_group, user)
+
+        last_message = ChatMessage.objects.filter(study_group=study_group).order_by("-created_at").first()
+
+        if last_message:
+            LastReadService.update_last_read(
+                study_group=study_group,
+                user=user,
+                message=last_message,
+            )

--- a/apps/chat/services/last_read_service.py
+++ b/apps/chat/services/last_read_service.py
@@ -1,8 +1,9 @@
+from django.core.exceptions import PermissionDenied
 from django.db import transaction
 
 from apps.chat.models.chat_message import ChatMessage
 from apps.chat.models.last_read_message import LastReadMessage
-from apps.study_groups.models import StudyGroup
+from apps.study_groups.models import GroupMember, StudyGroup
 from apps.users.models import User
 
 
@@ -14,6 +15,17 @@ class LastReadService:
     """
 
     @staticmethod
+    def _validate_member(study_group: StudyGroup, user: User) -> None:
+        # 해당 유저가 그룹 멤버인지 확인
+        is_member = GroupMember.objects.filter(
+            study_group_id=study_group.id,
+            user_id=user.id,
+        ).exists()
+
+        if not is_member:
+            raise PermissionDenied("그룹 멤버만 읽음 정보를 수정할 수 있습니다.")
+
+    @staticmethod
     @transaction.atomic
     def update_last_read(
         study_group: StudyGroup,
@@ -21,12 +33,11 @@ class LastReadService:
         message: ChatMessage,
     ) -> LastReadMessage:
         """
-        사용자가 스터디 그룹에서 마지막으로 읽은 메시지를 갱신합니다
-
-        동작 방식
-        - 동일한 (study_group, user) 조합은 하나만 존재해야 하므로 update_or_create 사용
-        - 동시에 여러 요청이 올라와도 atomic 처리로 race condition 방지
+        사용자가 스터디 그룹에서 마지막으로 읽은 메시지를 갱신
         """
+        # 그룹 구성원이 맞는지 검증
+        LastReadService._validate_member(study_group, user)
+
         last_read, _ = LastReadMessage.objects.update_or_create(
             study_group=study_group,
             user=user,


### PR DESCRIPTION
## ✅ PR 요약
그룹 멤버 검증, 메시지 조회, 읽음 처리 로직 추가

## 📄 상세 내용
1. ChatRoomService
- [ ] 그룹 멤버 여부 검사 로직 정리
- [ ] 채팅방 목록 조회 기능 추가
- [ ] 채팅방 메시지 조회 기능 강화
- [ ] 가입 이후의 메시지만 조회하도록 필터링
- [ ] 기본 limit=300, 이후 페이지는 커서 기반으로 100개씩 조회 가능

2. LastReadService
- [ ] 그룹 멤버 검증 추가
- [ ] member validation


## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
지금 올린 파일 머지 후 message_service.py와 함께 3개의 서비스 레이어에 대한 테스트 코드 푸쉬하겠습니다.

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
