### PR TITLE
[feat/chat] drf-spectacular 요청/응답 스키마 분리를 위한 Request/Response Serializer 추가

### DIFF
--- a/apps/chat/serializers/message_serializer.py
+++ b/apps/chat/serializers/message_serializer.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, cast
+from typing import Optional, cast
 
 from rest_framework import serializers
 from rest_framework.request import Request
@@ -63,3 +63,7 @@ class MessageSerializer(serializers.ModelSerializer[ChatMessage]):
             return False
 
         return obj.created_at <= last_read.message.created_at
+
+
+class MessageCreateRequestSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    content = serializers.CharField()

--- a/apps/chat/serializers/message_serializer.py
+++ b/apps/chat/serializers/message_serializer.py
@@ -1,10 +1,11 @@
-from typing import Optional, cast
+from typing import Any, Optional, cast
 
 from rest_framework import serializers
 from rest_framework.request import Request
 
 from apps.chat.models import ChatMessage, LastReadMessage
 from apps.users.models import User
+from config.settings.base import value
 
 
 class SenderSerializer(serializers.ModelSerializer[User]):
@@ -65,5 +66,18 @@ class MessageSerializer(serializers.ModelSerializer[ChatMessage]):
         return obj.created_at <= last_read.message.created_at
 
 
-class MessageCreateRequestSerializer(serializers.Serializer):  # type: ignore[type-arg]
-    content = serializers.CharField()
+class MessageCreateRequestSerializer(serializers.Serializer[Any]):
+    content = serializers.CharField(
+        max_length=1000,  # 필요시 조정 가능함
+        allow_blank=False,
+        trim_whitespace=True,
+    )
+
+    def validate_content(self, value: Any) -> str:
+        # 공백만 있는 문자 방지
+        text = cast(str, value)
+
+        if not text.strip():
+            raise serializers.ValidationError("메시지 내용은 비어 있을 수 없습니다.")
+
+        return text

--- a/apps/chat/serializers/response_serializer.py
+++ b/apps/chat/serializers/response_serializer.py
@@ -1,0 +1,9 @@
+from rest_framework import serializers
+
+
+class MarkAllReadResponseSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    detail = serializers.CharField()
+
+
+class ErrorResponseSerializer(serializers.Serializer):  # type: ignore[type-arg]
+    error_detail = serializers.CharField()


### PR DESCRIPTION
## ✅ PR 요약
스웨거 상에서 Response Body가 노출되지 않는 문제가 있어 이를 개선하고자 했습니다

## 📄 상세 내용
- [ ] 요청 스키마 분리를 위한 Request Serializer 추가
- MessageCreateRequestSerializer` 추가
- 메시지 생성 API POST body를 스웨거에서 명확히 표현하기 위해

- [ ] 공통 응답 스키마 분리를 위해 response_serializer.py 신규 생성
- MarkAllReadResponseSerializer 추가 (읽음 처리 200 응답)
- ErrorResponseSerializer 추가 (401, 403, 404 에러 응답)

## 📸 스크린샷 (선택)
<img width="1260" height="782" alt="image" src="https://github.com/user-attachments/assets/e58948fc-be6e-464f-af53-09f3b065c26b" />

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
