### PR TITLE
[feat/chat] 서비스 전체 리팩토링 및 테스트 일관성 확보

### DIFF
--- a/apps/chat/pagination.py
+++ b/apps/chat/pagination.py
@@ -1,0 +1,13 @@
+from rest_framework.pagination import CursorPagination, PageNumberPagination
+
+
+class ChatRoomCursorPagination(CursorPagination):
+    page_size = 10
+    ordering = "-created_at"
+    cursor_query_param = "cursor"
+
+
+class ChatRoomListPagination(PageNumberPagination):
+    page_size = 10
+    page_size_query_param = "page_size"
+    max_page_size = 100

--- a/apps/chat/serializers/chatroom_detail_serializer.py
+++ b/apps/chat/serializers/chatroom_detail_serializer.py
@@ -1,0 +1,14 @@
+from typing import Any
+
+from rest_framework import serializers
+
+
+class ChatroomDetailMemberSerializer(serializers.Serializer[Any]):
+    nickname = serializers.CharField(read_only=True)
+    is_leader = serializers.BooleanField(read_only=True)
+
+
+class ChatroomDetailSerializer(serializers.Serializer[Any]):
+    id = serializers.IntegerField(read_only=True)
+    name = serializers.CharField(read_only=True)
+    members = ChatroomDetailMemberSerializer(many=True, read_only=True)

--- a/apps/chat/serializers/chatroom_serializer.py
+++ b/apps/chat/serializers/chatroom_serializer.py
@@ -1,62 +1,23 @@
-from typing import Any, Dict, Optional
+from typing import Any
 
 from rest_framework import serializers
 
-from apps.chat.models import ChatMessage, LastReadMessage
-from apps.study_groups.models import StudyGroup
 
-from .message_serializer import SenderSerializer
-
-
-class LastMessageSummarySerializer(serializers.ModelSerializer[ChatMessage]):
-    sender = SenderSerializer(read_only=True)
-
-    class Meta:
-        model = ChatMessage
-        fields = ("id", "sender", "content", "created_at")
+class SenderMiniSerializer(serializers.Serializer[Any]):
+    id = serializers.IntegerField(read_only=True)
+    nickname = serializers.CharField(read_only=True)
 
 
-class ChatroomSerializer(serializers.ModelSerializer[StudyGroup]):
-    # study group 채팅방
-    last_message = serializers.SerializerMethodField()
-    unread_message = serializers.SerializerMethodField()
+class LastMessageSummarySerializer(serializers.Serializer[Any]):
+    id = serializers.IntegerField(read_only=True)
+    sender = SenderMiniSerializer(read_only=True)
+    content = serializers.CharField(read_only=True)
+    is_read = serializers.BooleanField(read_only=True)
+    created_at = serializers.DateTimeField(read_only=True)
 
-    class Meta:
-        model = StudyGroup
-        fields = (
-            "id",
-            "name",
-            "profile_img_url",
-            "start_at",
-            "end_at",
-            "last_message",
-            "unread_message",
-            "created_at",
-            "updated_at",
-        )
 
-    def get_last_message(self, obj: StudyGroup) -> Optional[Dict[str, Any]]:
-        last: Optional[ChatMessage] = obj.chat_messages.order_by("-created_at").select_related("sender").first()
-        if not last:
-            return None
-
-        return LastMessageSummarySerializer(last, context=self.context).data
-
-    def get_unread_message(self, obj: StudyGroup) -> Optional[int]:
-        request = self.context.get("request")
-        if not request or not request.user.is_authenticated:
-            return None
-
-        user = request.user
-
-        # 읽은 마지막 메시지 timestamp
-
-        last_read: Optional[LastReadMessage] = (
-            LastReadMessage.objects.filter(study_group=obj, user=user).select_related("message").first()
-        )
-        if not last_read or not getattr(last_read, "message", None):
-            count = obj.chat_messages.count()
-            return count if count > 0 else None
-
-        count = obj.chat_messages.filter(created_at__gt=last_read.message.created_at).count()
-        return count if count > 0 else None
+class ChatroomSerializer(serializers.Serializer[Any]):
+    id = serializers.IntegerField(read_only=True)
+    name = serializers.CharField(read_only=True)
+    unread_message = serializers.IntegerField(read_only=True)
+    last_message = LastMessageSummarySerializer(read_only=True, allow_null=True)

--- a/apps/chat/serializers/response_serializer.py
+++ b/apps/chat/serializers/response_serializer.py
@@ -1,9 +1,11 @@
+from typing import Any
+
 from rest_framework import serializers
 
 
-class MarkAllReadResponseSerializer(serializers.Serializer):  # type: ignore[type-arg]
+class ErrorResponseSerializer(serializers.Serializer[Any]):
     detail = serializers.CharField()
 
 
-class ErrorResponseSerializer(serializers.Serializer):  # type: ignore[type-arg]
-    error_detail = serializers.CharField()
+class MarkAllReadResponseSerializer(serializers.Serializer[Any]):
+    detail = serializers.CharField()

--- a/apps/chat/services/chatroom_service.py
+++ b/apps/chat/services/chatroom_service.py
@@ -1,7 +1,7 @@
-from typing import Any, Optional
+from typing import Any, Dict, List, Optional
 
-from django.core.exceptions import PermissionDenied
 from django.db.models import Count, QuerySet
+from rest_framework.exceptions import PermissionDenied
 
 from apps.chat.models.chat_message import ChatMessage
 from apps.chat.models.last_read_message import LastReadMessage
@@ -16,8 +16,8 @@ class ChatRoomService:
     @staticmethod
     def validate_member(study_group: StudyGroup, user: User) -> None:
         """
-        요청한 사용자가 해당 그룹 구성원인지 검사
-        구성원이 아니라면 PermissionDenied 예외를 강제 발생시키게끔 했습니다 !
+        요청한 사용자가 해당 그룹 구성원인지 검사.
+        구성원이 아니라면 PermissionDenied 예외 발생.
         """
         exists = GroupMember.objects.filter(
             study_group_id=study_group.id,
@@ -28,44 +28,37 @@ class ChatRoomService:
             raise PermissionDenied("그룹 멤버만 채팅을 조회할 수 있습니다.")
 
     @staticmethod
-    def get_chatrooms(user: User) -> list[dict[str, Any]]:
-        # 채팅방 목록 조회
+    def get_chatrooms(user: User) -> List[Dict[str, Any]]:
         memberships = GroupMember.objects.filter(user_id=user.id).select_related("study_group_id")
-
         groups = [m.study_group_id for m in memberships]
         group_ids = [g.id for g in groups]
 
         if not group_ids:
             return []
 
-        # 최신 메시지 가져오기
         last_messages = (
             ChatMessage.objects.filter(study_group_id__in=group_ids)
             .select_related("sender", "study_group")
             .order_by("study_group_id", "-created_at")
         )
 
-        last_message_map: dict[int, ChatMessage] = {}
+        last_message_map: Dict[int, ChatMessage] = {}
         for msg in last_messages:
             if msg.study_group_id not in last_message_map:
                 last_message_map[msg.study_group_id] = msg
 
-        # last_read 조회
-        last_reads = LastReadMessage.objects.filter(
-            user_id=user.id,
-            study_group_id__in=group_ids,
-        ).select_related("message")
-
+        last_reads = LastReadMessage.objects.filter(user_id=user.id, study_group_id__in=group_ids).select_related(
+            "message"
+        )
         last_read_map = {lr.study_group_id: lr for lr in last_reads}
 
-        # 총 메시지 수
         count_map = dict(
             ChatMessage.objects.filter(study_group_id__in=group_ids)
             .values_list("study_group_id")
             .annotate(total=Count("id"))
         )
 
-        results: list[dict[str, Any]] = []
+        results: List[Dict[str, Any]] = []
 
         for group in groups:
             last_message = last_message_map.get(group.id)
@@ -79,32 +72,41 @@ class ChatRoomService:
             else:
                 unread_count = count_map.get(group.id, 0)
 
+            if last_message:
+                sender = last_message.sender
+                assert sender is not None
+
+                last_message_data = {
+                    "id": last_message.id,
+                    "sender": {
+                        "id": sender.id,
+                        "nickname": sender.nickname,
+                    },
+                    "content": last_message.content,
+                    "created_at": last_message.created_at,
+                    "is_read": bool(last_read),
+                }
+            else:
+                last_message_data = None
+
             results.append(
                 {
                     "group_id": group.id,
                     "group_name": group.name,
-                    "last_message_content": last_message.content if last_message else None,
-                    "last_message_time": last_message.created_at if last_message else None,
                     "unread_count": unread_count,
+                    "last_message": last_message_data,
                 }
             )
 
         return results
 
     @staticmethod
-    def get_room_info(study_group: StudyGroup, user: User) -> dict[str, Any]:
-        # 채팅방 접속 시 필요한 기본 정보 조회
+    def get_room_info(study_group: StudyGroup, user: User) -> Dict[str, Any]:
         ChatRoomService.validate_member(study_group, user)
 
         members = GroupMember.objects.filter(study_group_id=study_group.id).select_related("user_id")
 
-        member_list = [
-            {
-                "nickname": m.user_id.nickname,
-                "is_leader": m.is_leader,
-            }
-            for m in members
-        ]
+        member_list = [{"nickname": m.user_id.nickname, "is_leader": m.is_leader} for m in members]
 
         return {
             "group_id": study_group.id,
@@ -127,19 +129,22 @@ class ChatRoomService:
             user_id=user.id,
         )
 
-        queryset = ChatMessage.objects.filter(
-            study_group_id=study_group.id,
-            created_at__gte=membership.created_at,
-        ).select_related("sender")
+        qs = (
+            ChatMessage.objects.filter(
+                study_group_id=study_group.id,
+                created_at__gte=membership.created_at,
+            )
+            .select_related("sender")
+            .order_by("-id")
+        )
 
         if cursor:
-            queryset = queryset.filter(id__lte=cursor)
+            qs = qs.filter(id__lte=cursor)
 
-        return queryset.order_by("-id")[:limit]
+        return qs
 
     @staticmethod
     def mark_all_read(study_group: StudyGroup, user: User) -> None:
-        # 채팅방 접속시 사용자가 이전에 읽지 않은 메시지를 가장 최신 메시지 기준으로 전부 읽음 처리
         ChatRoomService.validate_member(study_group, user)
 
         last_message = ChatMessage.objects.filter(study_group_id=study_group.id).order_by("-created_at").first()

--- a/apps/chat/services/message_service.py
+++ b/apps/chat/services/message_service.py
@@ -1,5 +1,6 @@
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import IntegrityError
+from rest_framework.exceptions import NotFound
 
 from apps.chat.models import ChatMessage
 from apps.study_groups.models import GroupMember, StudyGroup
@@ -14,7 +15,7 @@ class MessageService:
         # 해당 사용자가 그룹 구성원이 맞는지 검증
         is_member = GroupMember.objects.filter(
             study_group_id=study_group.id,
-            user_id=user.id,  # mypy 오류로 user 대신 user.id를 넘겼습니다.
+            user_id=user.id,
         ).exists()
 
         if not is_member:

--- a/apps/chat/tests/test_chatroom_service.py
+++ b/apps/chat/tests/test_chatroom_service.py
@@ -1,7 +1,7 @@
 import time
 
-from django.core.exceptions import PermissionDenied
 from django.test import TestCase
+from rest_framework.exceptions import PermissionDenied
 
 from apps.chat.models.chat_message import ChatMessage
 from apps.chat.models.last_read_message import LastReadMessage
@@ -80,6 +80,7 @@ class TestChatRoomService(TestCase):
     def test_get_room_info(self) -> None:
         info = ChatRoomService.get_room_info(self.group, self.user)
         self.assertEqual(info["group_id"], self.group.id)
+
         self.assertEqual(len(info["members"]), 1)
         self.assertEqual(info["members"][0]["nickname"], self.user.nickname)
 

--- a/apps/chat/tests/test_chatroom_view.py
+++ b/apps/chat/tests/test_chatroom_view.py
@@ -1,0 +1,112 @@
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.chat.models.chat_message import ChatMessage
+from apps.chat.models.last_read_message import LastReadMessage
+from apps.study_groups.models import GroupMember, StudyGroup
+from apps.users.models import User
+
+
+class TestChatRoomViews(APITestCase):
+    def setUp(self) -> None:
+        # 인증 완료된 사용자
+        self.user = User.objects.create(
+            email="test@example.com",
+            name="김오즈",
+            nickname="테스터",
+            phone_number="01012345678",
+            gender="M",
+            birthday="1999-01-01",
+            password="qwer1234",
+        )
+        self.client.force_authenticate(self.user)
+
+        self.anon_client = self.client_class()
+
+        # 다른 유저(그룹 미참여)
+        self.other_user = User.objects.create(
+            email="hayeong@example.com",
+            name="송하영",
+            nickname="ha0",
+            phone_number="01012341234",
+            gender="F",
+            birthday="1997-09-29",
+        )
+
+        # 스터디 그룹
+        self.group = StudyGroup.objects.create(
+            name="Django Study",
+            introduction="스터디 소개",
+            max_headcount=5,
+            start_at="2025-12-01T00:00:00Z",
+            end_at="2025-12-30T00:00:00Z",
+        )
+
+        # 그룹 멤버 등록
+        GroupMember.objects.create(
+            study_group_id=self.group,
+            user_id=self.user,
+        )
+
+        # 메시지 생성
+        self.msg1 = ChatMessage.objects.create(
+            study_group=self.group,
+            sender=self.user,
+            content="msg1",
+        )
+        self.msg2 = ChatMessage.objects.create(
+            study_group=self.group,
+            sender=self.user,
+            content="msg2",
+        )
+
+    # 채팅방 목록 조회 성공
+    def test_chatroom_list_success(self) -> None:
+        url = reverse("api_v1_chatrooms_list")
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("results", response.data)
+        self.assertGreaterEqual(len(response.data["results"]), 1)
+
+    # 채팅방 목록 조회 - 미인증 > 401
+    def test_chatroom_list_unauthenticated(self) -> None:
+        url = reverse("api_v1_chatrooms_list")
+        response = self.anon_client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    # 채팅방 상세 조회 성공
+    def test_chatroom_detail_success(self) -> None:
+        url = reverse("api_v1_chatrooms_retrieve", kwargs={"group_id": self.group.id})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["id"], self.group.id)
+
+    # 채팅방 상세 조회 - 존재하지 않음 > 404
+    def test_chatroom_detail_not_found(self) -> None:
+        url = reverse("api_v1_chatrooms_retrieve", kwargs={"group_id": 99999})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    # 전체 읽음 처리 성공
+    def test_mark_all_read_success(self) -> None:
+        url = reverse("api_v1_chatrooms_mark_all_read", kwargs={"group_id": self.group.id})
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        last_read = LastReadMessage.objects.get(study_group=self.group, user=self.user)
+        self.assertEqual(last_read.message.id, self.msg2.id)
+
+    # 전체 읽음 처리 - 미참여자 > 403
+    def test_mark_all_read_not_member(self) -> None:
+        self.client.force_authenticate(self.other_user)
+
+        url = reverse("api_v1_chatrooms_mark_all_read", kwargs={"group_id": self.group.id})
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/apps/chat/tests/test_message_view.py
+++ b/apps/chat/tests/test_message_view.py
@@ -1,0 +1,99 @@
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.chat.models.chat_message import ChatMessage
+from apps.study_groups.models import GroupMember, StudyGroup
+from apps.users.models import User
+
+
+class TestMessageViews(APITestCase):
+    def setUp(self) -> None:
+        self.user = User.objects.create(
+            email="test@example.com",
+            name="김오즈",
+            nickname="테스터",
+            phone_number="01012345678",
+            gender="M",
+            birthday="1999-01-01",
+            password="qwer1234",
+        )
+        self.client.force_authenticate(self.user)
+
+        self.other_user = User.objects.create(
+            email="hayeong@example.com",
+            name="송하영",
+            nickname="ha0",
+            phone_number="01012341234",
+            gender="F",
+            birthday="1997-09-29",
+            password="pass1234",
+        )
+
+        self.group = StudyGroup.objects.create(
+            name="Django Study",
+            introduction="스터디 소개",
+            max_headcount=5,
+            start_at="2025-12-01T00:00:00Z",
+            end_at="2025-12-30T00:00:00Z",
+        )
+
+        GroupMember.objects.create(
+            study_group_id=self.group,
+            user_id=self.user,
+        )
+
+        self.msg = ChatMessage.objects.create(
+            study_group=self.group,
+            sender=self.user,
+            content="hello test",
+        )
+
+    # 메시지 목록 조회 성공
+    def test_message_list(self) -> None:
+        url = reverse("api_v1_chatroom_message_list", kwargs={"group_id": self.group.id})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("results", response.data)
+        self.assertGreaterEqual(len(response.data["results"]), 1)
+
+    # 메시지 목록 조회 - 미참여자 > 403
+    def test_message_list_not_member(self) -> None:
+        self.client.force_authenticate(self.other_user)
+
+        url = reverse("api_v1_chatroom_message_list", kwargs={"group_id": self.group.id})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    # 메시지 생성 성공
+    def test_message_create_success(self) -> None:
+        url = reverse("api_v1_chatroom_message_create", kwargs={"group_id": self.group.id})
+
+        response = self.client.post(url, {"content": "새 메시지"}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["content"], "새 메시지")
+
+    # 메시지 생성 - 빈 내용 > 400
+    def test_message_create_empty_content(self) -> None:
+        url = reverse("api_v1_chatroom_message_create", kwargs={"group_id": self.group.id})
+
+        response = self.client.post(url, {"content": "   "}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    # 단일 메시지 조회 성공
+    def test_message_detail(self) -> None:
+        url = reverse("api_v1_messages_retrieve", kwargs={"message_id": self.msg.id})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    # 단일 메시지 조회 - 존재 X > 404
+    def test_message_detail_not_found(self) -> None:
+        url = reverse("api_v1_messages_retrieve", kwargs={"message_id": 999999})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/apps/chat/urls/v1.py
+++ b/apps/chat/urls/v1.py
@@ -1,0 +1,57 @@
+from django.urls import path
+
+from apps.chat.views.chatroom_view import (
+    ChatRoomDetailView,
+    ChatRoomListView,
+    ChatRoomMarkAllReadView,
+)
+from apps.chat.views.message_view import (
+    ChatRoomMessageListView,
+    MessageCreateView,
+    MessageDetailView,
+)
+
+urlpatterns = [
+    # 채팅방 목록 조회
+    path(
+        "chatrooms/",
+        ChatRoomListView.as_view(),
+        name="api_v1_chatrooms_list",
+    ),
+    # 채팅방 상세 조회
+    path(
+        "chatrooms/<int:group_id>/",
+        ChatRoomDetailView.as_view(),
+        name="api_v1_chatrooms_retrieve",
+    ),
+    # 채팅방 읽음 처리
+    path(
+        "chatrooms/<int:group_id>/read/",
+        ChatRoomMarkAllReadView.as_view(),
+        name="api_v1_chatrooms_mark_all_read",
+    ),
+    # 멤버별 읽음 처리 API
+    path(
+        "chatroom/<int:group_id>/members/<int:member_id>/read/",
+        ChatRoomMarkAllReadView.as_view(),
+        name="api_v1_chatrooms_mark_all_read_v2",
+    ),
+    # 메시지 목록 조회
+    path(
+        "chatrooms/<int:group_id>/messages/",
+        ChatRoomMessageListView.as_view(),
+        name="api_v1_chatroom_message_list",
+    ),
+    # 메시지 생성
+    path(
+        "chatrooms/<int:group_id>/messages/create/",
+        MessageCreateView.as_view(),
+        name="api_v1_chatroom_message_create",
+    ),
+    # 메시지 단건 조회
+    path(
+        "messages/<int:message_id>/",
+        MessageDetailView.as_view(),
+        name="api_v1_messages_retrieve",
+    ),
+]

--- a/apps/chat/views/chatroom_view.py
+++ b/apps/chat/views/chatroom_view.py
@@ -1,0 +1,103 @@
+from typing import cast
+
+from drf_spectacular.utils import extend_schema
+from rest_framework import permissions
+from rest_framework.exceptions import NotFound
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.chat.serializers.chatroom_serializer import ChatroomSerializer
+from apps.chat.serializers.response_serializer import (
+    ErrorResponseSerializer,
+    MarkAllReadResponseSerializer,
+)
+from apps.chat.services.chatroom_service import ChatRoomService
+from apps.study_groups.models import StudyGroup
+from apps.users.models import User
+
+
+class ChatRoomListView(APIView):
+    # 사용자가 참여한 채팅방 목록 조회 기능
+    permission_classes = [permissions.IsAuthenticated]
+
+    @extend_schema(
+        tags=["chat"],
+        summary="채팅방 목록 조회 API",
+        responses={200: ChatroomSerializer(many=True), 401: ErrorResponseSerializer},
+    )
+    def get(self, request: Request) -> Response:
+        user = cast(User, request.user)
+
+        rooms = ChatRoomService.get_chatrooms(user)
+
+        return Response(
+            {
+                "next": None,
+                "previous": None,
+                "results": rooms,
+            }
+        )
+
+
+class ChatRoomDetailView(APIView):
+    # 특정 스터디 그룹의 상세 정보 조회(그룹 채팅방)
+    # 참여자 목록, 그룹 정보 반환
+    permission_classes = [permissions.IsAuthenticated]
+
+    @extend_schema(
+        tags=["chat"],
+        summary="채팅방 정보 조회 API",
+        responses={200: ChatroomSerializer, 404: ErrorResponseSerializer, 403: ErrorResponseSerializer},
+    )
+    def get(self, request: Request, group_id: int) -> Response:
+        user = cast(User, request.user)
+
+        try:
+            group = StudyGroup.objects.get(id=group_id)
+        except StudyGroup.DoesNotExist:
+            raise NotFound("해당 채팅방을 찾을 수 없습니다.")
+
+        # 사용자 멤버십 검증
+        ChatRoomService.validate_member(group, user)
+
+        data = ChatRoomService.get_room_info(group, user)
+
+        return Response(
+            {
+                "id": data["group_id"],
+                "name": data["group_name"],
+                "members": data["members"],
+            }
+        )
+
+
+class ChatRoomMarkAllReadView(APIView):
+    # 사용자가 특정 채팅방의 모든 메시지를 읽음 처리
+    # LastReadMessage 테이블에 마지막에 읽은 메시지 기록
+    permission_classes = [permissions.IsAuthenticated]
+
+    @extend_schema(
+        tags=["chat"],
+        summary="채팅방 읽음 처리 API",
+        responses={
+            200: MarkAllReadResponseSerializer,
+            401: ErrorResponseSerializer,
+            403: ErrorResponseSerializer,
+            404: ErrorResponseSerializer,
+        },
+    )
+    def post(self, request: Request, group_id: int) -> Response:
+        user = cast(User, request.user)
+
+        try:
+            group = StudyGroup.objects.get(id=group_id)
+        except StudyGroup.DoesNotExist:
+            raise NotFound("해당 채팅방을 찾을 수 없습니다.")
+
+        # 사용자 멤버십 검증
+        ChatRoomService.validate_member(group, user)
+
+        ChatRoomService.mark_all_read(group, user)
+
+        return Response({"detail": "채팅 읽음 처리에 성공하였습니다."})

--- a/apps/chat/views/message_view.py
+++ b/apps/chat/views/message_view.py
@@ -1,0 +1,132 @@
+from typing import cast
+
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+from rest_framework import permissions
+from rest_framework.exceptions import NotFound, PermissionDenied
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.chat.pagination import ChatRoomCursorPagination
+from apps.chat.serializers.message_serializer import (
+    MessageCreateRequestSerializer,
+    MessageSerializer,
+)
+from apps.chat.serializers.response_serializer import ErrorResponseSerializer
+from apps.chat.services.chatroom_service import ChatRoomService
+from apps.chat.services.message_service import MessageService
+from apps.study_groups.models import StudyGroup
+from apps.users.models import User
+
+
+class ChatRoomMessageListView(APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    @extend_schema(
+        tags=["chat"],
+        summary="특정 채팅방의 메시지 목록 조회 API",
+        parameters=[
+            OpenApiParameter(name="cursor", type=OpenApiTypes.STR, location=OpenApiParameter.QUERY),
+            OpenApiParameter(name="page_size", type=OpenApiTypes.INT, location=OpenApiParameter.QUERY),
+        ],
+        responses={
+            200: MessageSerializer(many=True),
+            401: ErrorResponseSerializer,
+            403: ErrorResponseSerializer,
+            404: ErrorResponseSerializer,
+        },
+    )
+    def get(self, request: Request, group_id: int) -> Response:
+        user = cast(User, request.user)
+
+        try:
+            group = StudyGroup.objects.get(id=group_id)
+        except StudyGroup.DoesNotExist:
+            raise NotFound("해당 채팅방을 찾을 수 없습니다.")
+
+        # 그룹 멤버십 검증
+        ChatRoomService.validate_member(group, user)
+
+        cursor_str = request.query_params.get("cursor")
+        cursor = int(cursor_str) if cursor_str and cursor_str.isdigit() else None
+
+        qs = ChatRoomService.get_messages(
+            study_group=group,
+            user=user,
+            cursor=cursor,
+            limit=int(request.query_params.get("page_size", 100)),
+        )
+
+        paginator = ChatRoomCursorPagination()
+        page = paginator.paginate_queryset(qs, request)
+
+        serializer = MessageSerializer(page, many=True)
+        return paginator.get_paginated_response(serializer.data)
+
+
+class MessageCreateView(APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    @extend_schema(
+        tags=["chat"],
+        summary="메시지 생성 API",
+        request=MessageCreateRequestSerializer,
+        responses={
+            201: MessageSerializer,
+            400: ErrorResponseSerializer,
+            401: ErrorResponseSerializer,
+            403: ErrorResponseSerializer,
+            404: ErrorResponseSerializer,
+        },
+    )
+    def post(self, request: Request, group_id: int) -> Response:
+        user = cast(User, request.user)
+
+        try:
+            group = StudyGroup.objects.get(id=group_id)
+        except StudyGroup.DoesNotExist:
+            raise NotFound("해당 채팅방을 찾을 수 없습니다.")
+
+        # 그룹 멤버십 검증
+        ChatRoomService.validate_member(group, user)
+
+        serializer = MessageCreateRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        message = MessageService.create_message(
+            study_group=group,
+            user=user,
+            content=serializer.validated_data["content"],
+        )
+
+        return Response(MessageSerializer(message).data, status=201)
+
+
+class MessageDetailView(APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    @extend_schema(
+        tags=["chat"],
+        summary="메시지 상세 조회 API",
+        responses={
+            200: MessageSerializer,
+            404: ErrorResponseSerializer,
+            403: ErrorResponseSerializer,
+        },
+    )
+    def get(self, request: Request, message_id: int) -> Response:
+        user = cast(User, request.user)
+
+        try:
+            message = MessageService.get_message(message_id)
+        except Exception:
+            raise NotFound("메시지를 찾을 수 없습니다.")
+
+        # 메시지가 속한 그룹의 멤버인지 확인
+        try:
+            ChatRoomService.validate_member(message.study_group, user)
+        except PermissionDenied:
+            return Response({"detail": "해당 메시지에 접근 권한이 없습니다."}, status=403)
+
+        return Response(MessageSerializer(message).data)

--- a/config/urls.py
+++ b/config/urls.py
@@ -15,6 +15,7 @@ urlpatterns: list[URLPattern | URLResolver] = [
     path("api/v1/", include("apps.core.urls")),
     path("api/v1/", include("apps.application.urls")),
     path("api/v1", include("apps.users.urls.admin")),
+    path("api/v1/", include("apps.chat.urls.v1")),
 ]
 
 if settings.DEBUG:

--- a/schema.yml
+++ b/schema.yml
@@ -1,0 +1,2684 @@
+openapi: 3.0.3
+info:
+  title: 오즈 코딩 스쿨 Backend API
+  version: 1.0.0
+  description: 오즈 코딩 스쿨의 웹 사이트 개발을 위한 API입니다.
+paths:
+  /api/v1/admin/account:
+    get:
+      operationId: api_v1_admin_account_retrieve
+      description: 어드민 페이지 회원 목록 조회용 Spec API입니다.
+      summary: 어드민 페이지 회원 목록 조회 Spec
+      parameters:
+      - in: query
+        name: page
+        schema:
+          type: integer
+        description: '페이지 번호 / 기본값: 1'
+      - in: query
+        name: page_size
+        schema:
+          type: integer
+        description: '페이지 당 개수 / 기본값: 10'
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: 검색 (이메일, 닉네임, 이름)
+      - in: query
+        name: role
+        schema:
+          type: string
+          enum:
+          - admin
+          - staff
+          - user
+        description: 권한 필터 (user, staff, admin)
+      - in: query
+        name: status
+        schema:
+          type: string
+          enum:
+          - active
+          - inactive
+          - withdrew
+        description: 상세 필터 (active, inactive, withdrew)
+      tags:
+      - Admin
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminAccount'
+              examples:
+                SuccessExample:
+                  value:
+                    count: 4018
+                    next: http://api.ozcoding.site/api/v1/admin/accounts?page=1&page_size=10
+                    previous: null
+                    results:
+                    - id: 1
+                      email: user@example.com
+                      nickname: string
+                      name: string
+                      birthday: '2025-11-20'
+                      status: active
+                      role: user
+                      withdraw_at: '2025-10-30T14:01:57.505250+09:00'
+                      created_at: '2025-10-30T14:01:57.505250+09:00'
+                  summary: Success Example
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+              examples:
+                UnauthorizedExample:
+                  value:
+                    error_detail: 자격 인증 데이터가 제공되지 않았습니다.
+                  summary: Unauthorized Example
+          description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+              examples:
+                ForbiddenExample:
+                  value:
+                    error_detail: 권한이 없습니다.
+                  summary: Forbidden Example
+          description: ''
+  /api/v1/admin/account/{account_id}:
+    get:
+      operationId: api_v1_admin_account_retrieve_2
+      description: 어드민 페이지 회원 정보 상세 조회용 Spec API입니다.
+      summary: 어드민 페이지 회원 정보 상세 조회 Spec
+      parameters:
+      - in: path
+        name: account_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Admin
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminAccountDetail'
+              examples:
+                SuccessExample:
+                  value:
+                    id: 1
+                    name: 홍승우
+                    gender: M
+                    nickname: user1
+                    birthday: '2005-01-01'
+                    phone_number: 01012345678
+                    email: user1@example.com
+                    role: user
+                    status: active
+                    created_at: '2005-01-01T13:00:47.50525+09:00'
+                    profile_img_url: https://example.com/profile/user1.png
+                  summary: Success Example
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+              examples:
+                UnauthorizedExample:
+                  value:
+                    error_detail: 자격 인증 데이터가 제공되지 않았습니다.
+                  summary: Unauthorized Example
+          description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+              examples:
+                ForbiddenExample:
+                  value:
+                    error_detail: 권한이 없습니다.
+                  summary: Forbidden Example
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+              examples:
+                NotfoundExample:
+                  value:
+                    error_detail: 사용자 정보를 찾을 수 없습니다.
+                  summary: Notfound Example
+          description: ''
+  /api/v1/admin/applications:
+    get:
+      operationId: admin_application_list
+      description: '[REQ-APLY-009] 관리자용 지원서 목록 조회'
+      summary: Admin 지원서 목록 조회
+      parameters:
+      - in: query
+        name: page
+        schema:
+          type: integer
+      - in: query
+        name: page_size
+        schema:
+          type: integer
+      - in: query
+        name: search
+        schema:
+          type: string
+        description: 공고 제목 검색
+      - in: query
+        name: sort
+        schema:
+          type: string
+        description: latest | oldest
+      - in: query
+        name: status
+        schema:
+          type: string
+        description: 지원 상태 필터
+      tags:
+      - Application - Admin
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminApplicationList'
+          description: ''
+  /api/v1/admin/applications/{application_uuid}:
+    get:
+      operationId: api_v1_admin_applications_retrieve
+      description: '[REQ-APLY-010] 관리자용 지원서 상세 조회'
+      summary: Admin 지원서 상세 조회
+      parameters:
+      - in: path
+        name: application_uuid
+        schema:
+          type: string
+        required: true
+      tags:
+      - Application - Admin
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminApplicationDetail'
+          description: ''
+  /api/v1/admin/lectures:
+    get:
+      operationId: v1_admin_crawled_lectures_list
+      summary: 크롤링한 강의 목록 (관리자)
+      parameters:
+      - in: query
+        name: page
+        schema:
+          type: integer
+        description: 원하는 페이지 번호를 입력하여 해당하는 페이지의 강의 내용을 가져올 수 있습니다.
+      - in: query
+        name: page_size
+        schema:
+          type: integer
+        description: 한 페이지에 몇 개의 결과를 보여줄지 지정 할 수 있습니다.
+      - in: query
+        name: search
+        schema:
+          type: string
+        description: 강의 제목 또는 강사 이름으로 검색합니다.
+      tags:
+      - Admin Crawled Lectures
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedAdminCrawledLectureList'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                example:
+                  error_detail: 자격 인증 데이터가 제공되지 않았습니다.
+          description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                example:
+                  error_detail: 권한이 없습니다.
+          description: ''
+  /api/v1/admin/lectures/{lecture_id}:
+    get:
+      operationId: v1_admin_crawled_lecture_detail
+      summary: 크롤링한 강의 상세 조회 (관리자)
+      parameters:
+      - in: path
+        name: lecture_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - Admin Crawled Lectures
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminCrawledLectureRetrieve'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                example:
+                  error_detail: 자격 인증 데이터가 제공되지 않았습니다.
+          description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                example:
+                  error_detail: 권한이 없습니다.
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                example:
+                  error_detail: 강의 정보를 찾을 수 없습니다.
+          description: ''
+  /api/v1/applications/{application_uuid}:
+    get:
+      operationId: api_v1_applications_retrieve
+      description: '[REQ-APLY-007] 내가 지원한 상세 조회'
+      summary: 내 지원 상세 조회
+      parameters:
+      - in: path
+        name: application_uuid
+        schema:
+          type: string
+        required: true
+      tags:
+      - Application - Applicant
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApplicantApplicationDetail'
+          description: ''
+  /api/v1/applications/{application_uuid}/cancel:
+    post:
+      operationId: api_v1_applications_cancel_create
+      description: '[REQ-APLY-008] 지원 취소'
+      summary: 지원 취소
+      parameters:
+      - in: path
+        name: application_uuid
+        schema:
+          type: string
+        required: true
+      tags:
+      - Application - Applicant
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+  /api/v1/applications/mine:
+    get:
+      operationId: api_v1_applications_mine_retrieve
+      description: '[REQ-APLY-006] 내가 지원한 공고 목록 조회'
+      summary: 내 지원 목록 조회 (cursor)
+      parameters:
+      - in: query
+        name: cursor
+        schema:
+          type: string
+      - in: query
+        name: page_size
+        schema:
+          type: integer
+      tags:
+      - Application - Applicant
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApplicantApplicationList'
+          description: ''
+  /api/v1/chatroom/{group_id}/members/{member_id}/read/:
+    post:
+      operationId: api_v1_chatroom_members_read_create
+      summary: 채팅방 읽음 처리 API
+      parameters:
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: member_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - chat
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarkAllReadResponse'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+  /api/v1/chatrooms/:
+    get:
+      operationId: api_v1_chatrooms_retrieve
+      summary: 채팅방 목록 조회 API
+      tags:
+      - chat
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Chatroom'
+          description: ''
+  /api/v1/chatrooms/{group_id}/:
+    get:
+      operationId: api_v1_chatrooms_retrieve_2
+      summary: 채팅방 정보 조회 API
+      parameters:
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - chat
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChatRoomDetail'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+  /api/v1/chatrooms/{group_id}/messages/:
+    get:
+      operationId: api_v1_chatrooms_messages_list
+      summary: 특정 채팅방의 메시지 목록 조회 API
+      parameters:
+      - in: query
+        name: cursor
+        schema:
+          type: string
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - in: query
+        name: page_size
+        schema:
+          type: integer
+      tags:
+      - chat
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Message'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+  /api/v1/chatrooms/{group_id}/messages/create/:
+    post:
+      operationId: api_v1_chatrooms_messages_create_create
+      summary: 메시지 생성 API
+      parameters:
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - chat
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MessageCreateRequestRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/MessageCreateRequestRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/MessageCreateRequestRequest'
+        required: true
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Message'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+  /api/v1/chatrooms/{group_id}/read/:
+    post:
+      operationId: api_v1_chatrooms_read_create
+      summary: 채팅방 읽음 처리 API
+      parameters:
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - chat
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarkAllReadResponse'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+  /api/v1/lectures:
+    get:
+      operationId: api_v1_lectures_list
+      summary: 크롤링된 강의 목록을 조회하는 API입니다.
+      parameters:
+      - in: query
+        name: page
+        schema:
+          type: integer
+        description: 원하는 페이지 번호를 입력하여 해당하는 페이지의 강의 내용을 가져올 수 있습니다.
+      - in: query
+        name: page_size
+        schema:
+          type: integer
+        description: 한 페이지에 나타내는 강의 목록의 수를 조절할 수 있습니다.
+      - in: query
+        name: search
+        schema:
+          type: string
+        description: 강의 제목 또는 강사 이름으로 검색합니다.
+      - in: query
+        name: sort
+        schema:
+          type: string
+          enum:
+          - high_price
+          - high_rating
+          - latest
+          - low_price
+          - low_rating
+          - oldest
+        description: "\n아래의 정렬 기준을 선택할 수 있습니다:\n- latest : 최신순으로 정렬\n- oldest : 오래된순으로\
+          \ 정렬\n- low_price : 낮은 가격순으로 정렬\n- high_price : 높은 가격순으로 정렬\n- high_rating\
+          \ : 높은 리뷰 평점순으로 정렬\n- low_rating : 낮은 리뷰 평점순으로 정렬\n                "
+      tags:
+      - lectures
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedCrawledLectureList'
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                example:
+                  error_detail: 서버에서 알 수 없는 오류가 발생했습니다.
+          description: ''
+  /api/v1/messages/{message_id}/:
+    get:
+      operationId: api_v1_messages_retrieve
+      summary: 단일 메시지 조회 API
+      parameters:
+      - in: path
+        name: message_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - chat
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Message'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+  /api/v1/notifications:
+    get:
+      operationId: api_v1_notifications_retrieve
+      summary: 알림 목록 조회 API (읽음 여부 필터링 가능)
+      parameters:
+      - in: query
+        name: cursor
+        schema:
+          type: string
+        description: 특정 커서 위치에 해당하는 페이지를 조회할 수 있는 쿼리 파라미터 입니다.
+      - in: query
+        name: is_read
+        schema:
+          type: boolean
+        description: 읽음 여부 필터링 쿼리 파라미터 입니다.
+      - in: query
+        name: page_size
+        schema:
+          type: integer
+        description: 페이지 네이션 적용 시 각 페이지의 항목 수를 나타내는 쿼리 파라미터 입니다.
+      tags:
+      - Notification
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Notification'
+          description: ''
+  /api/v1/notifications{notification_id}/read:
+    post:
+      operationId: api_v1_notifications_read_create
+      summary: 로그인 유저가 수신한 특정 알림을 읽음 처리하는 API 입니다.
+      parameters:
+      - in: path
+        name: notification_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - notification
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                example:
+                  detail: 알림 읽음처리에 성공하였습니다.
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                type: object
+                example:
+                  error_detail: 자격 인증 데이터가 제공되지 않았습니다.
+          description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                type: object
+                example:
+                  error_detail: 권한이 없습니다.
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                type: object
+                example:
+                  error_detail: 해당 알림 내역을 찾을 수 없습니다.
+          description: ''
+  /api/v1/notificationsread-all:
+    post:
+      operationId: api_v1_notificationsread_all_create
+      summary: 로그인 유저가 수신한 알림중 읽지 않은 모든 알림을 읽음 처리하는 API 입니다.
+      tags:
+      - notification
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                example:
+                  detail: 모든 알림 읽음처리에 성공하였습니다.
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                type: object
+                example:
+                  error_detail: 자격 인증 데이터가 제공되지 않았습니다.
+          description: ''
+  /api/v1/recruitment-bookmarks:
+    get:
+      operationId: api_v1_recruitment_bookmarks_retrieve
+      description: Cursor Pagination 기반 북마크 목록 조회, 타이틀 검색 가능
+      summary: 스터디 구인 공고 북마크 목록 조회
+      tags:
+      - api
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecruitmentBookmarkCard'
+          description: ''
+    post:
+      operationId: api_v1_recruitment_bookmarks_create
+      summary: 스터디 구인 공고 북마크 생성
+      tags:
+      - api
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecruitmentBookmarkCreateRequest'
+            examples:
+              북마크요청:
+                value:
+                  recruitment_uuid: b8dbd77f-cf73-4ef4-ae15-34e6b6cf1b41
+                summary: 북마크 요청
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RecruitmentBookmarkCreateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RecruitmentBookmarkCreateRequest'
+        required: true
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      - {}
+      responses:
+        '200':
+          description: 북마크가 추가되었습니다.
+        '401':
+          description: 자격 인증 데이터가 제공되지 않았습니다.
+        '404':
+          description: 해당 공고를 찾을 수 없습니다.
+        '409':
+          description: 이미 북마크 한 공고입니다.
+  /api/v1/recruitment-bookmarks/{recruitment_uuid}:
+    delete:
+      operationId: api_v1_recruitment_bookmarks_destroy
+      summary: 스터디 구인 공고 북마크 삭제
+      parameters:
+      - in: path
+        name: recruitment_uuid
+        schema:
+          type: string
+          format: uuid
+        required: true
+      tags:
+      - api
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      - {}
+      responses:
+        '200':
+          description: 북마크가 취소되었습니다.
+        '401':
+          description: 자격 인증 데이터가 제공되지 않았습니다.
+        '403':
+          description: 권한이 없습니다.
+        '404':
+          description: 해당 북마크 내역을 찾을 수 없습니다.
+  /api/v1/recruitments/{recruitment_uuid}/applications:
+    post:
+      operationId: api_v1_recruitments_applications_create
+      description: '[REQ-APLY-001] 지원서 제출'
+      summary: 지원서 제출
+      parameters:
+      - in: path
+        name: recruitment_uuid
+        schema:
+          type: string
+        required: true
+      tags:
+      - Application - Applicant
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApplicationCreateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ApplicationCreateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ApplicationCreateRequest'
+        required: true
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+  /api/v1/s3-presigned-url:
+    get:
+      operationId: api_v1_s3_presigned_url_retrieve
+      description: 프론트엔드가 S3에 직접 파일을 업로드하기 위한 Presigned URL을 발급합니다.
+      summary: S3 Presigned URL 발급
+      parameters:
+      - in: query
+        name: content_type
+        schema:
+          type: string
+        description: 'MIME type (예: image/png, application/pdf)'
+        required: true
+      - in: query
+        name: file_ext
+        schema:
+          type: string
+        description: '파일 확장자 (예: png, pdf)'
+        required: true
+      - in: query
+        name: file_name
+        schema:
+          type: string
+        description: 원본 파일명
+        required: true
+      - in: query
+        name: type
+        schema:
+          type: string
+          enum:
+          - NOTE_ATTACHMENT
+          - NOTE_IMAGE
+          - RECRUITMENT_ATTACHMENT
+          - RECRUITMENT_IMAGE
+          - STUDY_GROUP_IMAGE
+          - USER_PROFILE_IMAGE
+        description: 파일 타입
+        required: true
+      tags:
+      - Common
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                description: 성공
+                content:
+                  application/json:
+                    example:
+                      upload_url: https://study-hub.s3.ap-northeast-2.amazonaws.com/uploads/users/profiles/uuid.png?X-Amz-Algorithm=...
+                      file_url: https://study-hub.s3.ap-northeast-2.amazonaws.com/uploads/users/profiles/uuid.png
+                      key: uploads/users/profiles/uuid.png
+                      headers:
+                        Content-Type: image/png
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                description: 잘못된 요청
+                content:
+                  application/json:
+                    examples:
+                      missing_params:
+                        summary: 필수 파라미터 누락
+                        value:
+                          error_detail:
+                            type:
+                            - 이 필드는 필수 항목입니다.
+                      invalid_type:
+                        summary: 유효하지 않은 파일 타입
+                        value:
+                          error_detail: '유효하지 않은 파일 타입: INVALID_TYPE'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                description: 인증 실패
+                content:
+                  application/json:
+                    example:
+                      error_detail: 자격 인증 데이터가 제공되지 않았습니다.
+          description: ''
+  /api/v1/study-groups:
+    get:
+      operationId: api_v1_study_groups_retrieve
+      description: 스터디 그룹 목록 조회
+      summary: 스터디 그룹 목록 조회 REQ-STDY-0002(GET)
+      parameters:
+      - in: query
+        name: status
+        schema:
+          type: string
+          enum:
+          - ENDED
+          - ONGOING
+          - PENDING
+          default: PENDING
+        description: 스터디 그룹 상태 필터
+      tags:
+      - StudyGroups
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StudyGroupList'
+          description: ''
+  /api/v1/study-groups/{id}:
+    get:
+      operationId: api_v1_study_groups_retrieve_2
+      description: 스터디 그룹 상세 조회
+      summary: 스터디 그룹 상세 조회 REQ-STDY-0003(GET)
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - StudyGroups
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StudyGroupDetail'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+  /api/v1/study-groups/{id}/delete:
+    delete:
+      operationId: api_v1_study_groups_delete_destroy
+      description: 스터디 그룹 삭제
+      summary: 스터디 그룹 삭제 REQ-STDY-0005(DELETE)
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - StudyGroups
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+  /api/v1/study-groups/{id}/update:
+    patch:
+      operationId: api_v1_study_groups_update_partial_update
+      description: 스터디 그룹 수정
+      summary: 스터디 그룹 수정 REQ-STDY-0004(PATCH)
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - StudyGroups
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedStudyGroupRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedStudyGroupRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedStudyGroupRequest'
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StudyGroup'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+  /api/v1/study-groups/create:
+    post:
+      operationId: api_v1_study_groups_create_create
+      description: 스터디 그룹 생성
+      summary: 스터디 그룹 생성 REQ-STDY-0001(POST)
+      tags:
+      - StudyGroups
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StudyGroupRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/StudyGroupRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/StudyGroupRequest'
+        required: true
+      security:
+      - jwtAuth: []
+      - BearerAuth:
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StudyGroup'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+components:
+  schemas:
+    AdminAccount:
+      type: object
+      description: 어드민 회원 목록 조회용 serializer
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        email:
+          type: string
+          format: email
+          maxLength: 254
+        nickname:
+          type: string
+          maxLength: 10
+        name:
+          type: string
+          maxLength: 30
+        birthday:
+          type: string
+          format: date
+        status:
+          type: string
+          readOnly: true
+        role:
+          type: string
+          readOnly: true
+        withdraw_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - birthday
+      - created_at
+      - email
+      - id
+      - name
+      - nickname
+      - role
+      - status
+      - withdraw_at
+    AdminAccountDetail:
+      type: object
+      description: 어드민 회원 정보 상세 조회용 serializer
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 30
+        gender:
+          $ref: '#/components/schemas/GenderEnum'
+        nickname:
+          type: string
+          maxLength: 10
+        birthday:
+          type: string
+          format: date
+        phone_number:
+          type: string
+          maxLength: 20
+        email:
+          type: string
+          format: email
+          maxLength: 254
+        role:
+          type: string
+          readOnly: true
+        status:
+          type: string
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        profile_img_url:
+          type: string
+          format: uri
+          maxLength: 255
+      required:
+      - birthday
+      - created_at
+      - email
+      - gender
+      - id
+      - name
+      - nickname
+      - phone_number
+      - profile_img_url
+      - role
+      - status
+    AdminApplicantDetail:
+      type: object
+      description: (Admin) 지원자 상세 정보
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        nickname:
+          type: string
+          readOnly: true
+        email:
+          type: string
+          format: email
+          readOnly: true
+        gender:
+          allOf:
+          - $ref: '#/components/schemas/GenderEnum'
+          readOnly: true
+        profile_img_url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - email
+      - gender
+      - id
+      - nickname
+      - profile_img_url
+    AdminApplicantSummary:
+      type: object
+      description: (Admin) 지원자 요약 정보
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        nickname:
+          type: string
+          readOnly: true
+        email:
+          type: string
+          format: email
+          readOnly: true
+      required:
+      - email
+      - id
+      - nickname
+    AdminApplicationDetail:
+      type: object
+      description: (Admin Page) 지원서 상세 조회
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        status:
+          type: string
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+        recruitment:
+          allOf:
+          - $ref: '#/components/schemas/AdminRecruitmentDetail'
+          readOnly: true
+        applicant:
+          allOf:
+          - $ref: '#/components/schemas/AdminApplicantDetail'
+          readOnly: true
+        self_introduction:
+          type: string
+          readOnly: true
+          description: 자기 소개
+        motivation:
+          type: string
+          readOnly: true
+          description: 지원 동기
+        objective:
+          type: string
+          readOnly: true
+          description: 지원 목표
+        available_time:
+          type: string
+          readOnly: true
+          description: '예시: 주 2회, 월/수 저녁 7시 이후 참여 가능'
+        has_study_experience:
+          type: boolean
+          readOnly: true
+          description: 과거에 스터디 참여한 경험이 있는지 여부
+        study_experience:
+          type: string
+          readOnly: true
+          description: 스터디 경험이 있다면 기재해주세요
+      required:
+      - applicant
+      - available_time
+      - created_at
+      - has_study_experience
+      - id
+      - motivation
+      - objective
+      - recruitment
+      - self_introduction
+      - status
+      - study_experience
+      - updated_at
+      - uuid
+    AdminApplicationList:
+      type: object
+      description: (Admin Page) 지원서 목록 조회
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        status:
+          type: string
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+        recruitment:
+          allOf:
+          - $ref: '#/components/schemas/AdminRecruitmentSummary'
+          readOnly: true
+        applicant:
+          allOf:
+          - $ref: '#/components/schemas/AdminApplicantSummary'
+          readOnly: true
+      required:
+      - applicant
+      - created_at
+      - id
+      - recruitment
+      - status
+      - updated_at
+      - uuid
+    AdminCrawledLecture:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        title:
+          type: string
+          readOnly: true
+          description: 강의명
+        instructor:
+          type: string
+          readOnly: true
+          description: 강사명
+        thumbnail_img_url:
+          type: string
+          format: uri
+          readOnly: true
+          nullable: true
+          description: 강의 썸네일 이미지
+        platform:
+          allOf:
+          - $ref: '#/components/schemas/PlatformEnum'
+          readOnly: true
+          description: |-
+            플랫폼
+
+            * `INFLEARN` - 인프런
+            * `UDEMY` - 유데미
+        url_link:
+          type: string
+          format: uri
+          readOnly: true
+          description: 강의 바로가기 링크
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - created_at
+      - id
+      - instructor
+      - platform
+      - thumbnail_img_url
+      - title
+      - updated_at
+      - url_link
+    AdminCrawledLectureRetrieve:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        title:
+          type: string
+          readOnly: true
+          description: 강의명
+        instructor:
+          type: string
+          readOnly: true
+          description: 강사명
+        description:
+          type: string
+          readOnly: true
+          description: 간략한 강의 상세 설명
+        total_class_time:
+          type: integer
+          readOnly: true
+          description: 총 강의 시간
+        original_price:
+          type: integer
+          readOnly: true
+          nullable: true
+          description: 강의 원가격
+        discounted_price:
+          type: integer
+          readOnly: true
+        difficulty:
+          allOf:
+          - $ref: '#/components/schemas/DifficultyEnum'
+          readOnly: true
+          description: |-
+            강의 난이도
+
+            * `EASY` - 초급
+            * `NORMAL` - 중급
+            * `HARD` - 어려움
+        thumbnail_img_url:
+          type: string
+          format: uri
+          readOnly: true
+          nullable: true
+          description: 강의 썸네일 이미지
+        average_rating:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,1}(?:\.\d{0,2})?$
+          readOnly: true
+          description: 리뷰 평점
+        platform:
+          allOf:
+          - $ref: '#/components/schemas/PlatformEnum'
+          readOnly: true
+          description: |-
+            플랫폼
+
+            * `INFLEARN` - 인프런
+            * `UDEMY` - 유데미
+        url_link:
+          type: string
+          format: uri
+          readOnly: true
+          description: 강의 바로가기 링크
+        categories:
+          type: array
+          items:
+            $ref: '#/components/schemas/Category'
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - average_rating
+      - categories
+      - created_at
+      - description
+      - difficulty
+      - discounted_price
+      - id
+      - instructor
+      - original_price
+      - platform
+      - thumbnail_img_url
+      - title
+      - total_class_time
+      - updated_at
+      - url_link
+    AdminRecruitmentDetail:
+      type: object
+      description: (Admin) 지원서 상세 조회에서 보여지는 Recruitment 상세 정보
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        title:
+          type: string
+          readOnly: true
+          description: 공고 제목
+        expected_headcount:
+          type: integer
+          readOnly: true
+          description: 예상 모집 인원 (1~10명)
+        close_at:
+          type: string
+          format: date-time
+          readOnly: true
+          description: 공고 마감일
+        lectures:
+          readOnly: true
+        tags:
+          readOnly: true
+      required:
+      - close_at
+      - expected_headcount
+      - id
+      - lectures
+      - tags
+      - title
+    AdminRecruitmentSummary:
+      type: object
+      description: (Admin) 공고 요약 정보
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+          description: 외부 노출용 ID
+        title:
+          type: string
+          readOnly: true
+          description: 공고 제목
+      required:
+      - id
+      - title
+      - uuid
+    ApplicantApplicationDetail:
+      type: object
+      description: 'REQ-APLY-007: 본인 지원 내역 상세'
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        status:
+          type: string
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+        self_introduction:
+          type: string
+          readOnly: true
+          description: 자기 소개
+        motivation:
+          type: string
+          readOnly: true
+          description: 지원 동기
+        objective:
+          type: string
+          readOnly: true
+          description: 지원 목표
+        available_time:
+          type: string
+          readOnly: true
+          description: '예시: 주 2회, 월/수 저녁 7시 이후 참여 가능'
+        has_study_experience:
+          type: boolean
+          readOnly: true
+          description: 과거에 스터디 참여한 경험이 있는지 여부
+        study_experience:
+          type: string
+          readOnly: true
+          description: 스터디 경험이 있다면 기재해주세요
+        recruitment:
+          allOf:
+          - $ref: '#/components/schemas/ApplicantRecruitmentMinimal'
+          readOnly: true
+      required:
+      - available_time
+      - created_at
+      - has_study_experience
+      - id
+      - motivation
+      - objective
+      - recruitment
+      - self_introduction
+      - status
+      - study_experience
+      - updated_at
+      - uuid
+    ApplicantApplicationList:
+      type: object
+      description: 'REQ-APLY-006: 내가 지원한 목록'
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        status:
+          type: string
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+        recruitment:
+          allOf:
+          - $ref: '#/components/schemas/RecruitmentSummary'
+          readOnly: true
+      required:
+      - created_at
+      - id
+      - recruitment
+      - status
+      - updated_at
+      - uuid
+    ApplicantRecruitmentMinimal:
+      type: object
+      description: 지원자 상세 조회에서 사용되는 최소한의 공고 정보
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+          description: 외부 노출용 ID
+        title:
+          type: string
+          readOnly: true
+          description: 공고 제목
+      required:
+      - title
+      - uuid
+    ApplicationCreateRequest:
+      type: object
+      description: 'REQ-APLY-001: 지원서 작성'
+      properties:
+        self_introduction:
+          type: string
+          minLength: 1
+          description: 자기 소개
+        motivation:
+          type: string
+          minLength: 1
+          description: 지원 동기
+        objective:
+          type: string
+          minLength: 1
+          description: 지원 목표
+          maxLength: 300
+        available_time:
+          type: string
+          minLength: 1
+          description: '예시: 주 2회, 월/수 저녁 7시 이후 참여 가능'
+          maxLength: 100
+        has_study_experience:
+          type: boolean
+          description: 과거에 스터디 참여한 경험이 있는지 여부
+        study_experience:
+          type: string
+          description: 스터디 경험이 있다면 기재해주세요
+      required:
+      - available_time
+      - motivation
+      - objective
+      - self_introduction
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          description: 카테고리명
+          maxLength: 255
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - created_at
+      - id
+      - name
+      - updated_at
+    ChatRoomDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        members:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+      required:
+      - id
+      - members
+      - name
+    Chatroom:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        unread_message:
+          type: integer
+        last_message:
+          allOf:
+          - $ref: '#/components/schemas/LastMessageSummary'
+          nullable: true
+      required:
+      - id
+      - last_message
+      - name
+      - unread_message
+    CrawledLecture:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        title:
+          type: string
+          readOnly: true
+          description: 강의명
+        instructor:
+          type: string
+          readOnly: true
+          description: 강사명
+        total_class_time:
+          type: integer
+          readOnly: true
+          description: 총 강의 시간
+        original_price:
+          type: integer
+          readOnly: true
+          nullable: true
+          description: 강의 원가격
+        discounted_price:
+          type: integer
+          readOnly: true
+        difficulty:
+          allOf:
+          - $ref: '#/components/schemas/DifficultyEnum'
+          readOnly: true
+          description: |-
+            강의 난이도
+
+            * `EASY` - 초급
+            * `NORMAL` - 중급
+            * `HARD` - 어려움
+        thumbnail_img_url:
+          type: string
+          format: uri
+          readOnly: true
+          nullable: true
+          description: 강의 썸네일 이미지
+        average_rating:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,1}(?:\.\d{0,2})?$
+          readOnly: true
+          description: 리뷰 평점
+        platform:
+          allOf:
+          - $ref: '#/components/schemas/PlatformEnum'
+          readOnly: true
+          description: |-
+            플랫폼
+
+            * `INFLEARN` - 인프런
+            * `UDEMY` - 유데미
+        url_link:
+          type: string
+          format: uri
+          readOnly: true
+          description: 강의 바로가기 링크
+        categories:
+          type: array
+          items:
+            $ref: '#/components/schemas/Category'
+          readOnly: true
+        reviews:
+          type: array
+          items:
+            $ref: '#/components/schemas/CrawledLectureReview'
+          readOnly: true
+      required:
+      - average_rating
+      - categories
+      - difficulty
+      - discounted_price
+      - id
+      - instructor
+      - original_price
+      - platform
+      - reviews
+      - thumbnail_img_url
+      - title
+      - total_class_time
+      - url_link
+    CrawledLectureReview:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        rating:
+          allOf:
+          - $ref: '#/components/schemas/RatingEnum'
+          readOnly: true
+          description: |-
+            리뷰의 평점
+
+            * `5` - 5점
+            * `4` - 4점
+            * `3` - 3점
+            * `2` - 2점
+            * `1` - 1점
+        content:
+          type: string
+          readOnly: true
+          description: 리뷰 내용
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - content
+      - created_at
+      - id
+      - rating
+    DifficultyEnum:
+      enum:
+      - EASY
+      - NORMAL
+      - HARD
+      type: string
+      description: |-
+        * `EASY` - 초급
+        * `NORMAL` - 중급
+        * `HARD` - 어려움
+    ErrorResponse:
+      type: object
+      properties:
+        detail:
+          type: string
+      required:
+      - detail
+    GenderEnum:
+      enum:
+      - M
+      - F
+      type: string
+      description: |-
+        * `M` - 남성
+        * `F` - 여성
+    LastMessageSummary:
+      type: object
+      properties:
+        id:
+          type: integer
+        sender:
+          $ref: '#/components/schemas/SenderMini'
+        content:
+          type: string
+        is_read:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+      required:
+      - content
+      - created_at
+      - id
+      - is_read
+      - sender
+    LectureSummary:
+      type: object
+      description: 강의 요약 정보
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        title:
+          type: string
+          readOnly: true
+          description: 강의명
+        instructor:
+          type: string
+          readOnly: true
+          description: 강사명
+      required:
+      - id
+      - instructor
+      - title
+    MarkAllReadResponse:
+      type: object
+      properties:
+        detail:
+          type: string
+      required:
+      - detail
+    Message:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        sender:
+          allOf:
+          - $ref: '#/components/schemas/Sender'
+          readOnly: true
+        content:
+          type: string
+          maxLength: 1000
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        is_read:
+          type: boolean
+          readOnly: true
+      required:
+      - content
+      - created_at
+      - id
+      - is_read
+      - sender
+    MessageCreateRequestRequest:
+      type: object
+      properties:
+        content:
+          type: string
+          minLength: 1
+          maxLength: 1000
+      required:
+      - content
+    Notification:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        type:
+          allOf:
+          - $ref: '#/components/schemas/TypeEnum'
+          readOnly: true
+        content:
+          type: string
+          readOnly: true
+        is_read:
+          type: boolean
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        back_url_link:
+          type: string
+          readOnly: true
+      required:
+      - back_url_link
+      - content
+      - created_at
+      - id
+      - is_read
+      - type
+    PaginatedAdminCrawledLectureList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/AdminCrawledLecture'
+    PaginatedCrawledLectureList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/CrawledLecture'
+    PatchedStudyGroupRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 20
+        introduction:
+          type: string
+          nullable: true
+          maxLength: 500
+        max_headcount:
+          type: integer
+          maximum: 32767
+          minimum: -32768
+        profile_img_url:
+          type: string
+          format: uri
+          nullable: true
+          maxLength: 200
+        start_at:
+          type: string
+          format: date-time
+        end_at:
+          type: string
+          format: date-time
+        lectures:
+          type: array
+          items:
+            type: integer
+            minimum: 1
+          description: Lecture 목록(최대 5개)
+          maxItems: 5
+    PlatformEnum:
+      enum:
+      - INFLEARN
+      - UDEMY
+      type: string
+      description: |-
+        * `INFLEARN` - 인프런
+        * `UDEMY` - 유데미
+    RatingEnum:
+      enum:
+      - 5
+      - 4
+      - 3
+      - 2
+      - 1
+      type: integer
+      description: |-
+        * `5` - 5점
+        * `4` - 4점
+        * `3` - 3점
+        * `2` - 2점
+        * `1` - 1점
+    RecruitmentBookmarkCard:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        study_group_recruitment_title:
+          type: string
+          readOnly: true
+        thumbnail_img_url:
+          type: string
+          nullable: true
+          readOnly: true
+        expected_headcount:
+          type: integer
+          readOnly: true
+        lectures:
+          type: array
+          items:
+            $ref: '#/components/schemas/RecruitmentLecture'
+          readOnly: true
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/RecruitmentTag'
+          readOnly: true
+        close_at:
+          type: string
+          format: date-time
+          readOnly: true
+        views_count:
+          type: integer
+          readOnly: true
+        bookmark_count:
+          type: integer
+          readOnly: true
+      required:
+      - bookmark_count
+      - close_at
+      - expected_headcount
+      - id
+      - lectures
+      - study_group_recruitment_title
+      - tags
+      - thumbnail_img_url
+      - views_count
+    RecruitmentBookmarkCreateRequest:
+      type: object
+      properties:
+        recruitment_uuid:
+          type: string
+          format: uuid
+      required:
+      - recruitment_uuid
+    RecruitmentLecture:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        title:
+          type: string
+          description: 강의명
+          maxLength: 255
+        instructor:
+          type: string
+          description: 강사명
+          maxLength: 20
+      required:
+      - id
+      - instructor
+      - title
+    RecruitmentSummary:
+      type: object
+      description: 공고 요약 정보
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+          description: 외부 노출용 ID
+        title:
+          type: string
+          readOnly: true
+          description: 공고 제목
+        expected_headcount:
+          type: integer
+          readOnly: true
+          description: 예상 모집 인원 (1~10명)
+        thumbnail_img_url:
+          type: string
+          readOnly: true
+        close_at:
+          type: string
+          format: date-time
+          readOnly: true
+          description: 공고 마감일
+        end_at:
+          type: string
+          format: date-time
+          readOnly: true
+        lectures:
+          type: array
+          items:
+            $ref: '#/components/schemas/LectureSummary'
+          readOnly: true
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/TagSummary'
+          readOnly: true
+      required:
+      - close_at
+      - end_at
+      - expected_headcount
+      - lectures
+      - tags
+      - thumbnail_img_url
+      - title
+      - uuid
+    RecruitmentTag:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          description: 태그 이름
+          maxLength: 20
+      required:
+      - id
+      - name
+    Sender:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        nickname:
+          type: string
+          maxLength: 10
+        profile_img_url:
+          type: string
+          nullable: true
+          readOnly: true
+      required:
+      - id
+      - nickname
+      - profile_img_url
+    SenderMini:
+      type: object
+      properties:
+        id:
+          type: integer
+        nickname:
+          type: string
+      required:
+      - id
+      - nickname
+    StatusEnum:
+      enum:
+      - PENDING
+      - ONGOING
+      - ENDED
+      type: string
+      description: |-
+        * `PENDING` - Pending
+        * `ONGOING` - Ongoing
+        * `ENDED` - Ended
+    StudyGroup:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 20
+        introduction:
+          type: string
+          nullable: true
+          maxLength: 500
+        max_headcount:
+          type: integer
+          maximum: 32767
+          minimum: -32768
+        profile_img_url:
+          type: string
+          format: uri
+          nullable: true
+          maxLength: 200
+        start_at:
+          type: string
+          format: date-time
+        end_at:
+          type: string
+          format: date-time
+        status:
+          allOf:
+          - $ref: '#/components/schemas/StatusEnum'
+          readOnly: true
+        lectures:
+          type: array
+          items:
+            type: integer
+            minimum: 1
+          description: Lecture 목록(최대 5개)
+          maxItems: 5
+      required:
+      - end_at
+      - id
+      - max_headcount
+      - name
+      - start_at
+      - status
+    StudyGroupDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 20
+        introduction:
+          type: string
+          nullable: true
+          maxLength: 500
+        profile_img_url:
+          type: string
+          format: uri
+          nullable: true
+          maxLength: 200
+        start_at:
+          type: string
+          format: date-time
+        end_at:
+          type: string
+          format: date-time
+        status:
+          $ref: '#/components/schemas/StatusEnum'
+        lectures:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+          readOnly: true
+        members:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+          readOnly: true
+      required:
+      - end_at
+      - id
+      - lectures
+      - members
+      - name
+      - start_at
+    StudyGroupList:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 20
+        member_count:
+          type: string
+          readOnly: true
+        is_leader:
+          type: boolean
+          readOnly: true
+        profile_img_url:
+          type: string
+          format: uri
+          nullable: true
+          maxLength: 200
+        start_at:
+          type: string
+          format: date-time
+        end_at:
+          type: string
+          format: date-time
+        status:
+          $ref: '#/components/schemas/StatusEnum'
+        lectures:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+          readOnly: true
+      required:
+      - end_at
+      - id
+      - is_leader
+      - lectures
+      - member_count
+      - name
+      - start_at
+    StudyGroupRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 20
+        introduction:
+          type: string
+          nullable: true
+          maxLength: 500
+        max_headcount:
+          type: integer
+          maximum: 32767
+          minimum: -32768
+        profile_img_url:
+          type: string
+          format: uri
+          nullable: true
+          maxLength: 200
+        start_at:
+          type: string
+          format: date-time
+        end_at:
+          type: string
+          format: date-time
+        lectures:
+          type: array
+          items:
+            type: integer
+            minimum: 1
+          description: Lecture 목록(최대 5개)
+          maxItems: 5
+      required:
+      - end_at
+      - max_headcount
+      - name
+      - start_at
+    TagSummary:
+      type: object
+      description: 태그 요약 정보
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          readOnly: true
+          description: 태그 이름
+      required:
+      - id
+      - name
+    TypeEnum:
+      enum:
+      - STUDY_JOIN
+      - STUDY_NOTE_CREATE
+      - STUDY_REVIEW_REQUEST
+      - APPLICATION_ACCEPT
+      - APPLICATION_REJECT
+      - ADD_APPLICATION
+      - TODAY_SCHEDULE
+      - UPCOMING_SCHEDULE
+      type: string
+      description: |-
+        * `STUDY_JOIN` - 스터디 그룹에 새로운 구성원이 참가한 경우 알림
+        * `STUDY_NOTE_CREATE` - 스터디 구성원이 스터디 기록을 작성한 경우 알림
+        * `STUDY_REVIEW_REQUEST` - 스터디 종료가 도래한 경우 알림
+        * `APPLICATION_ACCEPT` - 지원내역이 승인된 경우 알림
+        * `APPLICATION_REJECT` - 지원내역이 거절된 경우 알림
+        * `ADD_APPLICATION` - 공고를 올린 스터디 그룹의 리더에게 새로운 지원내역이 있는 경우 알림
+        * `TODAY_SCHEDULE` - 금일 스케줄 알림
+        * `UPCOMING_SCHEDULE` - 스케줄 하루 전에 임박한 예정 스케줄 알림
+  securitySchemes:
+    jwtAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT


### PR DESCRIPTION
Service, Serializer, View 구조 통일 및 테스트 일치화 작업

## ✅ PR 요약
chatroom 및 message 기능 전반의 응답 구조가 API 명세서, Swagger 예시, 테스트 코드 각각에 맞지 않아 
 서비스, 시리얼라이저, 뷰를 전면적으로 리팩토링했습니다.

## 📄 상세 내용
ChatRoomService
- [ ] 기존 Model 기반 응답에서 dict 기반 응답으로 전환
- [ ] last_message 구조를 API 명세서 기반으로 재정비
- [ ] unread_count 계산 로직 개선

MessageService
- [ ] create_message 빈 문자열 처리 개선

ChatroomSerializer
- [ ] last_message 구조를 SenderMiniSerializer + is_read까지 포함하도록 변경

ChatroomDetailSerializer (새로 만듦)
- [ ] 상세 조회 전용 구조 정의

ChatRoomListView
- [ ] next, previous, results 구조로 고정

ChatRoomDetailView
- [ ] ChatroomDetailSerializer 기반으로 결과 구성

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
