### PR TITLE
[Feat/crawled_lecture] crawled_lecture_serializer 필드 변환 추가

### DIFF
--- a/apps/lectures/serializers/crawled_lecture_serializer.py
+++ b/apps/lectures/serializers/crawled_lecture_serializer.py
@@ -1,3 +1,4 @@
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from apps.lectures.models import CrawledLecture
@@ -13,6 +14,7 @@ class CrawledLectureSerializer(serializers.ModelSerializer[CrawledLecture]):
     categories = CategorySerializer(source="mock_crawled_lecture_categories", many=True, read_only=True)  # mock
     discounted_price = serializers.IntegerField(source="discount_price", read_only=True)
     reviews = CrawledLectureReviewSerializer(source="mock_crawled_lecture_reviews", many=True, read_only=True)  # mock
+    average_rating = serializers.SerializerMethodField()
 
     class Meta:
         model = CrawledLecture
@@ -32,3 +34,9 @@ class CrawledLectureSerializer(serializers.ModelSerializer[CrawledLecture]):
             "reviews",
         ]
         read_only_fields = fields
+
+    @extend_schema_field(float)
+    def get_average_rating(self, obj: CrawledLecture) -> float:
+        if obj.average_rating is None:
+            return 0.0
+        return float(f"{obj.average_rating:.1f}")


### PR DESCRIPTION
## ✅ PR 요약

- 작업 요약: 시리얼라이저에서 average rating 필드의 자료형을 decimal → float로 변환하여 JSON 양식으로 직렬화하도록 추가

## 📄 상세 내용
- [x] SerializerMethodField를 사용하여 float를 반환하도록 변경

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
