### PR TITLE
[chore/withdraw] 회원 탈퇴 문서 작성을 위한 성공 메세지 입력

### DIFF
--- a/apps/users/services/withdrawal_services.py
+++ b/apps/users/services/withdrawal_services.py
@@ -8,7 +8,9 @@ from apps.users.models import User, Withdrawal
 
 def withdraw_service(user: User, withdrawal_data: dict[str, Any]) -> Withdrawal:
     if not user.is_active:
-        raise ValidationError("이미 탈퇴 처리된 유저 입니다. 다시 로그인 하시면 계정 복구를 진행하실 수 있습니다.")
+        raise ValidationError(
+            {"non_field_errors": "이미 탈퇴 처리된 유저 입니다. 다시 로그인 하시면 계정 복구를 진행하실 수 있습니다."}
+        )
     with transaction.atomic():
         withdrawal = Withdrawal.objects.create(user=user, **withdrawal_data)
         user.is_active = False

--- a/apps/users/services/withdrawal_services.py
+++ b/apps/users/services/withdrawal_services.py
@@ -1,15 +1,22 @@
 from typing import Any
 
 from django.db import transaction
-from rest_framework.exceptions import ValidationError
+from rest_framework import status
+from rest_framework.exceptions import APIException
 
 from apps.users.models import User, Withdrawal
 
 
+class AlreadyLockedAccount(APIException):
+    status_code = status.HTTP_423_LOCKED
+    default_detail = "해당 리소스가 존재하지만 접근 불가능한 상태"
+    default_code = "already_locked"
+
+
 def withdraw_service(user: User, withdrawal_data: dict[str, Any]) -> Withdrawal:
     if not user.is_active:
-        raise ValidationError(
-            {"non_field_errors": "이미 탈퇴 처리된 유저 입니다. 다시 로그인 하시면 계정 복구를 진행하실 수 있습니다."}
+        raise AlreadyLockedAccount(
+            {"non_field_errors": ["이미 탈퇴 처리된 유저 입니다. 다시 로그인 하시면 계정 복구를 진행하실 수 있습니다."]}
         )
     with transaction.atomic():
         withdrawal = Withdrawal.objects.create(user=user, **withdrawal_data)

--- a/apps/users/tests/test_withdrawals.py
+++ b/apps/users/tests/test_withdrawals.py
@@ -186,6 +186,10 @@ class WithdrawalCheckView(APITestCase):
         self.assertEqual(Withdrawal.objects.count(), 0)
         self.assertIn("error_detail", response.data)
         self.assertEqual(
-            response.data["error_detail"][0],
-            "이미 탈퇴 처리된 유저 입니다. 다시 로그인 하시면 계정 복구를 진행하실 수 있습니다.",
+            response.data["error_detail"],
+            (
+                {
+                    "non_field_errors": "이미 탈퇴 처리된 유저 입니다. 다시 로그인 하시면 계정 복구를 진행하실 수 있습니다."
+                }
+            ),
         )

--- a/apps/users/tests/test_withdrawals.py
+++ b/apps/users/tests/test_withdrawals.py
@@ -10,7 +10,10 @@ from rest_framework.exceptions import ValidationError as APIErrorValid
 from rest_framework.test import APITestCase
 
 from apps.users.models import User, Withdrawal
-from apps.users.services.withdrawal_services import withdraw_service
+from apps.users.services.withdrawal_services import (
+    AlreadyLockedAccount,
+    withdraw_service,
+)
 
 
 # model 테스트
@@ -110,7 +113,7 @@ class WithdrawalCheckService(TransactionTestCase):
             "reason": "TOO_DIFFICULT",
             "reason_detail": "이미 탈퇴한 유저 테스트 입니다.",
         }
-        with self.assertRaises(APIErrorValid):
+        with self.assertRaises(AlreadyLockedAccount):
             withdraw_service(self.user, data)
 
         self.assertEqual(Withdrawal.objects.count(), 0)
@@ -180,7 +183,7 @@ class WithdrawalCheckView(APITestCase):
         }
         response = self.client.delete(url, data=data, format="json")
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_423_LOCKED)
         self.user.refresh_from_db()
         self.assertFalse(self.user.is_active)
         self.assertEqual(Withdrawal.objects.count(), 0)
@@ -189,7 +192,9 @@ class WithdrawalCheckView(APITestCase):
             response.data["error_detail"],
             (
                 {
-                    "non_field_errors": "이미 탈퇴 처리된 유저 입니다. 다시 로그인 하시면 계정 복구를 진행하실 수 있습니다."
+                    "non_field_errors": [
+                        "이미 탈퇴 처리된 유저 입니다. 다시 로그인 하시면 계정 복구를 진행하실 수 있습니다."
+                    ]
                 }
             ),
         )

--- a/apps/users/tests/test_withdrawals.py
+++ b/apps/users/tests/test_withdrawals.py
@@ -143,7 +143,7 @@ class WithdrawalCheckView(APITestCase):
         }
         response = self.client.delete(url, data=data, format="json")
 
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.user.refresh_from_db()
         self.assertFalse(self.user.is_active)
         self.assertEqual(Withdrawal.objects.count(), 1)
@@ -164,7 +164,7 @@ class WithdrawalCheckView(APITestCase):
         self.assertTrue(self.user.is_active)
         self.assertEqual(Withdrawal.objects.count(), 0)
         self.assertIn("error_detail", response.data)
-        self.assertEqual(response.data["error_detail"], "회원 탈퇴에 동의해야 탈퇴 가능합니다.")
+        self.assertEqual(response.data["error_detail"]["agree_check"][0], "회원 탈퇴에 동의해야 탈퇴 가능합니다.")
 
     # 이미 탈퇴한 회원이 다시 탈퇴 신청을 할 경우 ( 실패 case )
     def test_withdrawal_view_already_active(self) -> None:

--- a/apps/users/views/user_account_views.py
+++ b/apps/users/views/user_account_views.py
@@ -17,7 +17,7 @@ from apps.users.services.withdrawal_services import withdraw_service
         description="회원 탈퇴를 위한 스키마 입니다. 14일 후 영구 삭제 됩니다.",
         request=WithdrawalSerializer,
         methods=["DELETE"],
-        responses={200: OpenApiTypes.OBJECT, 400: OpenApiTypes.OBJECT},
+        responses={200: OpenApiTypes.OBJECT, 400: OpenApiTypes.OBJECT, 423: OpenApiTypes.OBJECT},
         examples=[
             OpenApiExample(
                 request_only=True,
@@ -40,7 +40,7 @@ from apps.users.services.withdrawal_services import withdraw_service
             ),
             OpenApiExample(
                 response_only=True,
-                name="error_response",
+                name="already_locked",
                 summary="탈퇴 실패 예시 (이미 탈퇴함)",
                 value={
                     "error_detail": {
@@ -49,7 +49,7 @@ from apps.users.services.withdrawal_services import withdraw_service
                         ]
                     }
                 },
-                status_codes=["400"],
+                status_codes=["423"],
             ),
         ],
     )

--- a/apps/users/views/user_account_views.py
+++ b/apps/users/views/user_account_views.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema_view, OpenApiExample, extend_schema
 from rest_framework import permissions, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -7,6 +9,51 @@ from rest_framework.views import APIView
 from apps.users.serializers.withdrawal_serializers import WithdrawalSerializer
 from apps.users.services.withdrawal_services import withdraw_service
 
+@extend_schema_view(
+    delete=extend_schema(
+        tags=['Account'],
+        summary="회원 탈퇴",
+        description="회원 탈퇴를 위한 스키마 입니다. 14일 후 영구 삭제 됩니다.",
+        request=WithdrawalSerializer,
+        methods=['DELETE'],
+        responses={
+            200: OpenApiTypes.OBJECT,
+            400: OpenApiTypes.OBJECT
+        },
+        examples=[
+            OpenApiExample(
+                request_only=True,
+                name="success_case",
+                summary="탈퇴 요청 데이터 예시",
+                value={
+                    "reason": "TOO_DIFFICULT",
+                    "reason_detail": "탈퇴 테스트 양식 입니다.",
+                    "agree_check": True,
+                },
+            ),
+            OpenApiExample(
+                response_only=True,
+                name="success_response",
+                summary="탈퇴 성공 응답 예시",
+                value={
+                    "detail": "회원 탈퇴 처리가 완료되었습니다. 14일 후 계정이 영구 삭제되며, 그전에 다시 로그인하시면 계정을 복구하실 수 있습니다."
+                },
+                status_codes=["200"],
+            ),
+            OpenApiExample(
+                response_only=True,
+                name="error_response",
+                summary="탈퇴 실패 예시 (이미 탈퇴함)",
+                value={
+                    "error_detail": {
+                        "non_field_errors": ["이미 탈퇴 처리된 유저 입니다. 다시 로그인 하시면 계정 복구를 진행하실 수 있습니다."]
+                    }
+                },
+                status_codes=["400"],
+            )
+        ]
+    )
+)
 
 class UserAccountView(APIView):
     permission_classes = (permissions.IsAuthenticated,)

--- a/apps/users/views/user_account_views.py
+++ b/apps/users/views/user_account_views.py
@@ -23,4 +23,4 @@ class UserAccountView(APIView):
         data.pop("agree_check")
 
         withdraw_service(request.user, data)
-        return Response({"detail": "회원 탈퇴 처리가 완료되었습니다. 14일 후 계정이 영구 삭제되며, 그전에 다시 로그인하시면 계정을 복구하실 수 있습니다."}, status=status.HTTP_204_NO_CONTENT)
+        return Response({"detail": "회원 탈퇴 처리가 완료되었습니다. 14일 후 계정이 영구 삭제되며, 그전에 다시 로그인하시면 계정을 복구하실 수 있습니다."}, status=status.HTTP_200_OK)

--- a/apps/users/views/user_account_views.py
+++ b/apps/users/views/user_account_views.py
@@ -23,4 +23,4 @@ class UserAccountView(APIView):
         data.pop("agree_check")
 
         withdraw_service(request.user, data)
-        return Response({}, status=status.HTTP_204_NO_CONTENT)
+        return Response({"detail": "회원 탈퇴 처리가 완료되었습니다. 14일 후 계정이 영구 삭제되며, 그전에 다시 로그인하시면 계정을 복구하실 수 있습니다."}, status=status.HTTP_204_NO_CONTENT)

--- a/apps/users/views/user_account_views.py
+++ b/apps/users/views/user_account_views.py
@@ -21,4 +21,9 @@ class UserAccountView(APIView):
         data.pop("agree_check")
 
         withdraw_service(request.user, data)
-        return Response({"detail": "회원 탈퇴 처리가 완료되었습니다. 14일 후 계정이 영구 삭제되며, 그전에 다시 로그인하시면 계정을 복구하실 수 있습니다."}, status=status.HTTP_200_OK)
+        return Response(
+            {
+                "detail": "회원 탈퇴 처리가 완료되었습니다. 14일 후 계정이 영구 삭제되며, 그전에 다시 로그인하시면 계정을 복구하실 수 있습니다."
+            },
+            status=status.HTTP_200_OK,
+        )

--- a/apps/users/views/user_account_views.py
+++ b/apps/users/views/user_account_views.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import extend_schema_view, OpenApiExample, extend_schema
+from drf_spectacular.utils import OpenApiExample, extend_schema, extend_schema_view
 from rest_framework import permissions, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -9,17 +9,15 @@ from rest_framework.views import APIView
 from apps.users.serializers.withdrawal_serializers import WithdrawalSerializer
 from apps.users.services.withdrawal_services import withdraw_service
 
+
 @extend_schema_view(
     delete=extend_schema(
-        tags=['Account'],
+        tags=["Account"],
         summary="회원 탈퇴",
         description="회원 탈퇴를 위한 스키마 입니다. 14일 후 영구 삭제 됩니다.",
         request=WithdrawalSerializer,
-        methods=['DELETE'],
-        responses={
-            200: OpenApiTypes.OBJECT,
-            400: OpenApiTypes.OBJECT
-        },
+        methods=["DELETE"],
+        responses={200: OpenApiTypes.OBJECT, 400: OpenApiTypes.OBJECT},
         examples=[
             OpenApiExample(
                 request_only=True,
@@ -46,15 +44,16 @@ from apps.users.services.withdrawal_services import withdraw_service
                 summary="탈퇴 실패 예시 (이미 탈퇴함)",
                 value={
                     "error_detail": {
-                        "non_field_errors": ["이미 탈퇴 처리된 유저 입니다. 다시 로그인 하시면 계정 복구를 진행하실 수 있습니다."]
+                        "non_field_errors": [
+                            "이미 탈퇴 처리된 유저 입니다. 다시 로그인 하시면 계정 복구를 진행하실 수 있습니다."
+                        ]
                     }
                 },
                 status_codes=["400"],
-            )
-        ]
+            ),
+        ],
     )
 )
-
 class UserAccountView(APIView):
     permission_classes = (permissions.IsAuthenticated,)
 

--- a/apps/users/views/user_account_views.py
+++ b/apps/users/views/user_account_views.py
@@ -15,9 +15,7 @@ class UserAccountView(APIView):
         serializer = WithdrawalSerializer(data=request.data)
 
         if not serializer.is_valid():
-            error_key = next(iter(serializer.errors))
-            error_call = serializer.errors[error_key][0]
-            return Response({"error_detail": error_call}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({"error_detail": serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
 
         data = serializer.validated_data
         data.pop("agree_check")


### PR DESCRIPTION
## ✅ PR 요약
- 회원 탈퇴 문서 작성을 위한 성공 메세지 입력
- 이미 탈퇴한 유저 400 -> 423 변경

## 📄 상세 내용
- [x] 회원 탈퇴 body 값이 공백이라 비워뒀던 성공 메세지 입력 후 문서와 동기화
- [x] 테스트 코드 dict, list 값 불일치로 인한 수정  
- [x] 이미 탈퇴한 유저 에러 코드 400 -> 423 Locked 로 처리 완료 
## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
