### PR TITLE
[Feat/crawled lecture] 크롤링된 강의 목록 조회 API moack data -> 실기능 전환

### DIFF
--- a/apps/lectures/models/crawled_lecture.py
+++ b/apps/lectures/models/crawled_lecture.py
@@ -1,14 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from django.db import models
 from django.db.models.enums import TextChoices
 
 from apps.core.models import TimeStampedModel
-
-if TYPE_CHECKING:
-    from apps.lectures.models import Category, CrawledLectureReview
 
 
 class CrawledLecture(TimeStampedModel):
@@ -44,51 +39,3 @@ class CrawledLecture(TimeStampedModel):
 
     def __str__(self) -> str:
         return f"[{self.difficulty}] ({self.instructor}) {self.title}"
-
-    @property
-    def mock_crawled_lecture_categories(self) -> list[Category]:
-        import random
-        from datetime import datetime, timedelta
-
-        tags = [
-            "artificial-intelligence",
-            "Applied-ai",
-            "it-programming",
-            "game-dev-all",
-            "data-science",
-            "it",
-            "hardware",
-            "design",
-        ]
-
-        from apps.lectures.models import Category
-
-        return [
-            Category(
-                id=random.randint(1, 100),
-                name=tag,
-                created_at=(now := datetime(random.randint(2000, 2025), random.randint(1, 12), random.randint(1, 28))),
-                updated_at=now + timedelta(days=random.randint(0, 365)),
-            )
-            for tag in random.sample(tags, 2)
-        ]
-
-    @property
-    def mock_crawled_lecture_reviews(self) -> list[CrawledLectureReview]:
-        import random
-        from datetime import datetime, timedelta
-
-        from apps.lectures.models.crawled_lecture_review import CrawledLectureReview
-
-        return [
-            CrawledLectureReview(
-                id=random.randint(1, 100),
-                lecture=self,
-                external_id=random.randint(1, 100),
-                rating=random.choice([rating[0] for rating in CrawledLectureReview.RatingEnum.choices]),
-                content=f"예시 내용{i}",
-                created_at=(now := datetime(random.randint(2000, 2025), random.randint(1, 12), random.randint(1, 28))),
-                updated_at=now + timedelta(days=random.randint(0, 365)),
-            )
-            for i in range(1, 5)
-        ]

--- a/apps/lectures/serializers/crawled_lecture_serializer.py
+++ b/apps/lectures/serializers/crawled_lecture_serializer.py
@@ -9,11 +9,11 @@ from apps.lectures.serializers.crawled_lecture_review_serializer import (
 
 
 class CrawledLectureSerializer(serializers.ModelSerializer[CrawledLecture]):
-    # categories = CategorySerializer(source="lecture_categories.category", many=True, read_only=True) 실기능
-    # reviews = CrawledLectureReviewSerializer(many=True, read_only=True) 실기능
-    categories = CategorySerializer(source="mock_crawled_lecture_categories", many=True, read_only=True)  # mock
     discounted_price = serializers.IntegerField(source="discount_price", read_only=True)
-    reviews = CrawledLectureReviewSerializer(source="mock_crawled_lecture_reviews", many=True, read_only=True)  # mock
+
+    categories = CategorySerializer(many=True, read_only=True)
+    reviews = CrawledLectureReviewSerializer(many=True, read_only=True)
+
     average_rating = serializers.SerializerMethodField()
 
     class Meta:

--- a/apps/lectures/tests/crawled_lecture_test.py
+++ b/apps/lectures/tests/crawled_lecture_test.py
@@ -1,0 +1,100 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.lectures.models import (
+    Category,
+    CrawledLecture,
+    CrawledLectureReview,
+    LectureCategory,
+)
+
+User = get_user_model()
+
+
+class CrawledLectureViewTest(TestCase):
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.lectures = []
+
+        for i in range(1, 16):
+            lecture = CrawledLecture.objects.create(
+                external_id=i,
+                title=f"제목 {i}",
+                instructor=f"강사 {i}",
+                description="테스트 설명",
+                total_class_time=i * 10,
+                original_price=10000 + i,
+                discount_price=8000 + i,
+                difficulty="HARD",
+                thumbnail_img_url=f"https://thumbnail{i}.com",
+                average_rating=4.5,
+                platform="UDEMY",
+                url_link=f"https://url{i}.com",
+            )
+            self.lectures.append(lecture)
+
+            for j in range(1, 3):
+                category, _ = Category.objects.get_or_create(name=f"카테고리 {j}")
+                LectureCategory.objects.create(lecture=lecture, category=category)
+
+            for k in range(1, 4):
+                CrawledLectureReview.objects.create(
+                    lecture=lecture, external_id=k, rating=4.0 + k * 0.1, content=f"테스트 리뷰 {k}"
+                )
+
+        self.url = reverse("lectures")
+
+    def test_list_default_pagination_and_nested_fields(self) -> None:
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()
+        self.assertIn("results", data)
+        self.assertEqual(len(data["results"]), 12)
+        self.assertEqual(data["count"], 15)
+
+        first = data["results"][0]
+        self.assertIn("categories", first)
+        self.assertEqual(len(first["categories"]), 2)
+        self.assertIn("reviews", first)
+        self.assertEqual(len(first["reviews"]), 3)
+
+        self.assertIn("카테고리 1", [c["name"] for c in first["categories"]])
+        self.assertIn("테스트 리뷰 1", [r["content"] for r in first["reviews"]])
+
+    def test_list_custom_page_size(self) -> None:
+        response = self.client.get(self.url, {"page_size": 5})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()
+        self.assertEqual(len(data["results"]), 5)
+        self.assertEqual(data["count"], 15)
+
+    def test_list_search_title(self) -> None:
+        response = self.client.get(self.url, {"search": "제목 1"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertTrue(all("제목 1" in item["title"] for item in data["results"]))
+
+    def test_list_search_instructor(self) -> None:
+        response = self.client.get(self.url, {"search": "강사 2"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()
+        self.assertTrue(all("강사 2" in item["instructor"] for item in data["results"]))
+
+    def test_list_sort_high_price(self) -> None:
+        response = self.client.get(self.url, {"sort": "high_price"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()
+        prices = [item["discounted_price"] for item in data["results"]]
+        self.assertEqual(prices, sorted(prices, reverse=True)[: len(prices)])
+
+    def test_anonymous_access(self) -> None:
+        client = APIClient()
+        response = client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/apps/lectures/views/crawled_lecture_view.py
+++ b/apps/lectures/views/crawled_lecture_view.py
@@ -112,34 +112,10 @@ class CrawledLectureListAPIView(APIView):
         },
     )
     def get(self, request: Request) -> Response:
-        import random
-        from decimal import Decimal
-
-        mock_data = [
-            CrawledLecture(
-                id=random.randint(1, 1000),
-                external_id=random.randint(1, 1000),
-                title=f"제목{i}",
-                instructor=f"강사{i}",
-                average_rating=Decimal(random.randint(100, 500) / 100),
-                total_class_time=random.randint(1, 60),
-                difficulty=random.choice([difficulty[0] for difficulty in CrawledLecture.DifficultyEnum.choices]),
-                platform=random.choice([platform[0] for platform in CrawledLecture.PlatformEnum.choices]),
-                original_price=random.randint(1, 1000),
-                discount_price=random.randint(1, 1000),
-                url_link=f"https://example_url_{i}.com",
-                thumbnail_img_url=f"https://example_thumbnail_{i}.com",
-            )
-            for i in range(15)
-        ]
         paginator = self.pagination_class()
-        page: list[CrawledLecture] | None
 
-        if settings.DEBUG:
-            page = paginator.paginate_queryset(mock_data, request)  # type: ignore[arg-type]
-        else:
-            queryset = self.get_queryset()
-            page = paginator.paginate_queryset(queryset, request)
+        queryset = self.get_queryset()
+        page: list[CrawledLecture] | None = paginator.paginate_queryset(queryset, request)
 
         serializer = self.serializer_class(page, many=True)
         return paginator.get_paginated_response(serializer.data)

--- a/apps/lectures/views/crawled_lecture_view.py
+++ b/apps/lectures/views/crawled_lecture_view.py
@@ -41,7 +41,7 @@ class CrawledLectureListAPIView(APIView):
 
     @extend_schema_field(dict)
     def get_queryset(self) -> QuerySet[CrawledLecture]:
-        queryset = CrawledLecture.objects.all()
+        queryset = CrawledLecture.objects.prefetch_related("categories", "reviews").all()
 
         filterset = self.filterset_class(data=self.request.GET, queryset=queryset, request=self.request)
         queryset = cast(QuerySet[CrawledLecture], filterset.qs)


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 크롤링된 강의 목록 조회 API를 mock data 출력을 없애고 실기능을 처리하도록 수정했습니다.

## 📄 상세 내용
- [x] crawled_lecture 모델에서 mock data 함수를 삭제했습니다.
- [x] crawled_lecture_serializer에서 mock data 함수를 받아 처리하는 것을 실제 모델에서 가져오도록 수정했습니다.
- [x] 더 이상 mock data를 처리하지 않으므로, crawled_lecture_view에서  mock_data를 반환하는 구문을 삭제했습니다.
- [x] 실기능을 처리하는 crawled_lecture_view에 대한 테스트를 작성했습니다.

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
