### PR TITLE
[Feat/auth_email] 기존 회원 가입에 이메일 인증 로직 추가

### DIFF
--- a/apps/users/serializers/email_auth_serializer.py
+++ b/apps/users/serializers/email_auth_serializer.py
@@ -1,0 +1,31 @@
+from typing import Any
+
+from django.contrib.auth import get_user_model
+from rest_framework import serializers
+
+from apps.users.utils.auth_code import AuthCodeCache
+
+User = get_user_model()
+
+
+class EmailSignUpSerializer(serializers.Serializer[Any]):
+    email = serializers.EmailField(required=True)
+
+    def validate_email(self, value: str) -> str:
+        if User.objects.filter(email=value).exists():
+            raise serializers.ValidationError("이미 가입되어 있는 이메일 입니다.")
+        return value
+
+
+class EmailSignUpVerifySerializer(serializers.Serializer[Any]):
+    email = serializers.EmailField(required=True)
+    code = serializers.CharField(required=True)
+
+    def validate(self, data: Any) -> Any:
+        email = data["email"]
+        code = data["code"]
+        key = f"email:signup:{email}"
+
+        if not AuthCodeCache.verify(key, code):
+            raise serializers.ValidationError({"code": ["인증 코드가 올바르지 않거나 만료되었습니다."]})
+        return data

--- a/apps/users/serializers/user_serializer.py
+++ b/apps/users/serializers/user_serializer.py
@@ -2,6 +2,7 @@ import re
 from typing import Any
 
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from rest_framework import serializers
 
 User = get_user_model()
@@ -69,3 +70,11 @@ class UserSerializer(serializers.ModelSerializer[Any]):
 
         instance.save()
         return instance
+
+    def validate(self, data: dict[str, Any]) -> Any:
+        email = data.get("email")
+        if email:
+            get_verified_email = cache.get(f"verified:email:{email}")
+            if not get_verified_email:
+                raise serializers.ValidationError({"email": ["이메일 인증을 완료해야 가입하실 수 있습니다."]})
+        return data

--- a/apps/users/tests/test_auth.py
+++ b/apps/users/tests/test_auth.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch  # mocking 전용 import
+
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 from rest_framework import status
@@ -20,8 +22,16 @@ class test_user_register(APITestCase):
             "gender": "M",
             "birthday": "1990-01-01",
         }
+        # 이메일 인증 PASS 임시 mocking code
+        self.patcher = patch("django.core.cache.cache.get")
+        self.mock_cache_get = self.patcher.start()
+        self.mock_cache_get.return_value = "true"
+        # -------------------------------
 
     def tearDown(self) -> None:
+        # 이메일 인증 PASS 임시 mocking code
+        self.patcher.stop()
+        # -------------------------------
         User.objects.all().delete()
 
     def test_success_register(self) -> None:

--- a/apps/users/tests/test_email_auth.py
+++ b/apps/users/tests/test_email_auth.py
@@ -1,0 +1,67 @@
+from typing import Any
+from unittest.mock import patch
+
+from django.core.cache import cache
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
+
+
+class EmailAuthTestCase(APITestCase):
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.send_url = reverse("send-email")
+        self.verify_url = reverse("verify-email")
+        self.email = "testemail@test.com"
+
+    def tearDown(self) -> None:
+        cache.clear()
+
+    @patch("apps.users.utils.send_auth.send_mail")
+    def test_send_email_success(self, mock_send_mail: Any) -> None:
+        response = self.client.post(self.send_url, {"email": self.email})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        redis_key = f"email:signup:{self.email}"
+        self.assertIsNotNone(cache.get(redis_key))
+
+    def test_send_email_invalid_format(self) -> None:
+        response = self.client.post(self.send_url, {"email": "not-an-email"})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_send_email_duplicate(self) -> None:
+        from django.contrib.auth import get_user_model
+
+        User = get_user_model()
+        User.objects.create_user(
+            email=self.email,
+            password="password",
+            nickname="test",
+            phone_number="01000000000",
+            name="test",
+            gender="M",
+            birthday="2000-01-01",
+        )
+
+        response = self.client.post(self.send_url, {"email": self.email})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_verify_email_success(self) -> None:
+        code = "123456"
+        cache.set(f"email:signup:{self.email}", code, timeout=300)
+
+        response = self.client.post(self.verify_url, {"email": self.email, "code": code})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(cache.get(f"verified:email:{self.email}"), True)
+
+    def test_verify_email_wrong_code(self) -> None:
+        cache.set(f"email:signup:{self.email}", "123456", timeout=300)
+
+        response = self.client.post(self.verify_url, {"email": self.email, "code": "000000"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_verify_email_expired(self) -> None:
+        response = self.client.post(self.verify_url, {"email": self.email, "code": "123456"})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/apps/users/urls/account_urls.py
+++ b/apps/users/urls/account_urls.py
@@ -1,5 +1,6 @@
 from django.urls import path
 
+from apps.users.views.email_auth_views import EmailSignUpVerifyView, EmailSignUpView
 from apps.users.views.user_account_views import (
     NicknameCheckView,
     UserAccountView,
@@ -11,6 +12,8 @@ from apps.users.views.user_register import SignupView
 urlpatterns = [
     path("accounts/me", UserAccountView.as_view(), name="account"),
     path("accounts/signup", SignupView.as_view(), name="signup"),
+    path("accounts/signup/send-email", EmailSignUpView.as_view(), name="send-email"),
+    path("accounts/signup/verify-email", EmailSignUpVerifyView.as_view(), name="verify-email"),
     path("accounts/check-nickname", NicknameCheckView.as_view(), name="check-nickname"),
     path("accounts/find-password", UserPasswordResetView.as_view(), name="find-password"),
     path("accounts/login", LoginView.as_view(), name="login"),

--- a/apps/users/views/email_auth_views.py
+++ b/apps/users/views/email_auth_views.py
@@ -1,0 +1,88 @@
+from typing import Any
+
+from django.core.cache import cache
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiExample, extend_schema
+from rest_framework import status
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.users.serializers.email_auth_serializer import (
+    EmailSignUpSerializer,
+    EmailSignUpVerifySerializer,
+)
+from apps.users.utils.send_auth import SendAuth
+
+
+class EmailSignUpView(APIView):
+    permission_classes = (AllowAny,)
+
+    @extend_schema(
+        tags=["Account"],
+        summary="회원 가입 시 이메일 인증 발송",
+        description="회원 가입 시 필요한 인증용 이메일을 발송합니다.",
+        request=EmailSignUpSerializer,
+        methods=["POST"],
+        responses={200: EmailSignUpSerializer, 400: OpenApiTypes.OBJECT},
+        examples=[
+            OpenApiExample(
+                name="Success",
+                response_only=True,
+                status_codes=["200"],
+                value={"detail": "회원가입을 위한 이메일 인증 코드가 전송되었습니다."},
+            ),
+            OpenApiExample(
+                name="Bad Request",
+                response_only=True,
+                status_codes=["400"],
+                value={"error_detail": {"code": ["이미 가입되어 있는 이메일 입니다."]}},
+            ),
+        ],
+    )
+    def post(self, request: Any, *args: Any, **kwargs: Any) -> Response:
+        serializer = EmailSignUpSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response({"error_detail": serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
+        email = serializer.validated_data["email"]
+
+        email_auth = SendAuth.send_signup_email(email)
+
+        if email_auth.status_code == status.HTTP_200_OK:
+            return Response({"detail": "회원가입을 위한 이메일 인증 코드가 전송되었습니다."}, status=status.HTTP_200_OK)
+        return email_auth
+
+
+class EmailSignUpVerifyView(APIView):
+    permission_classes = (AllowAny,)
+
+    @extend_schema(
+        tags=["Account"],
+        summary="회원 가입 시 이메일 코드 검증",
+        description="전송된 가입용 이메일 인증 코드를 검증합니다.",
+        request=EmailSignUpVerifySerializer,
+        methods=["POST"],
+        responses={200: EmailSignUpVerifySerializer, 400: OpenApiTypes.OBJECT},
+        examples=[
+            OpenApiExample(
+                name="Success",
+                response_only=True,
+                status_codes=["200"],
+                value={"detail": "회원가입을 위한 이메일 인증에 성공하였습니다."},
+            ),
+            OpenApiExample(
+                name="Bad Request",
+                response_only=True,
+                status_codes=["400"],
+                value={"error_detail": {"email": ["인증 코드가 올바르지 않거나 만료되었습니다."]}},
+            ),
+        ],
+    )
+    def post(self, request: Any, *args: Any, **kwargs: Any) -> Response:
+        serializer = EmailSignUpVerifySerializer(data=request.data)
+        if serializer.is_valid():
+            email = serializer.validated_data["email"].lower()
+            cache.set(f"verified:email:{email}", True, timeout=900)
+
+            return Response({"detail": "회원가입을 위한 이메일 인증에 성공하였습니다."}, status=status.HTTP_200_OK)
+        return Response({"error_detail": serializer.errors}, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## ✅ PR 요약
- 기존 회원 가입에 이메일 인증 로직 추가

## 📄 상세 내용
- [x] 기존 이메일 인증 함수 API 명세서에 맞게 작동 코드 작성
- [x] 회원 가입 시 이메일 인증 필요

## 📸 스크린샷 (선택)
<img width="1752" height="934" alt="image" src="https://github.com/user-attachments/assets/2ef78e14-20d8-4328-841b-c40884c3ee6b" />

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
