### PR TITLE
[Fix/category/ser]   fields에서 created_at, updated_at 삭제

### DIFF
--- a/apps/lectures/serializers/category_serializer.py
+++ b/apps/lectures/serializers/category_serializer.py
@@ -6,5 +6,5 @@ from apps.lectures.models import Category
 class CategorySerializer(serializers.ModelSerializer[Category]):
     class Meta:
         model = Category
-        fields = ["id", "name", "created_at", "updated_at"]
-        read_only_fields = ["id", "created_at", "updated_at"]
+        fields = ["id", "name"]
+        read_only_fields = ["id"]


### PR DESCRIPTION
## ✅ PR 요약

- 작업 요약:  category fields에서 created_at, updated_at 삭제

## 📄 상세 내용
- [x] created_at, updated_at 삭제

## 📝 기타 참고 사항

- 프앤쪽에서 카테고리 자체의 created_at, updated_at이 나오는게 아닌것 같다고 하셔서 수정했습니다.
- 모델은 계속 timestampmodel 유지했습니다.

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.

