### PR TITLE
[refactor/chat] 채팅방 멤버 presence 조회 로직 및 JSON 전송 방식 개선

### DIFF
--- a/apps/chat/consumers/chat_consumer.py
+++ b/apps/chat/consumers/chat_consumer.py
@@ -153,7 +153,7 @@ class ChatConsumer(AsyncWebsocketConsumer):  # type: ignore
 
     async def safe_send(self, payload: Dict[str, Any]) -> None:
         try:
-            await self.send(text_data=json.dumps(payload))
+            await self.send(text_data=json.dumps(payload, ensure_ascii=False))
         except Exception:
             pass
 
@@ -177,19 +177,19 @@ class ChatConsumer(AsyncWebsocketConsumer):  # type: ignore
 
     @database_sync_to_async  # type: ignore[misc]
     def get_group_members(self) -> List[Dict[str, Any]]:
-        members = GroupMember.objects.filter(study_group_id=self.group_id).select_related("user")
+        members = GroupMember.objects.filter(study_group_id=self.group_id)
 
         redis = get_redis_connection("default")
-        online_set = redis.smembers(f"chat_online:{self.group_id}")
-        online_ids = {int(uid) for uid in online_set}
+        online_ids = {int(uid) for uid in redis.smembers(f"chat_online:{self.group_id}")}
 
         result = []
         for m in members:
+            user = m.user_id
             result.append(
                 {
-                    "id": m.user.id,  # type: ignore[attr-defined]
-                    "nickname": m.user.nickname,  # type: ignore[attr-defined]
-                    "is_online": m.user.id in online_ids,  # type: ignore[attr-defined]
+                    "id": user.id,
+                    "nickname": user.nickname,
+                    "is_online": user.id in online_ids,
                     "is_host": m.is_leader,
                 }
             )

--- a/apps/chat/consumers/chat_consumer.py
+++ b/apps/chat/consumers/chat_consumer.py
@@ -3,10 +3,13 @@ from typing import Any, Dict, List, Optional
 
 from channels.db import database_sync_to_async  # type: ignore
 from channels.generic.websocket import AsyncWebsocketConsumer  # type: ignore
-from django_redis import get_redis_connection  # type: ignore
 from rest_framework_simplejwt.tokens import AccessToken
 
-from apps.chat.models import ChatMessage, LastReadMessage
+from apps.chat.models import ChatMessage
+from apps.chat.services.history_service import HistoryService
+from apps.chat.services.message_service import MessageService
+from apps.chat.services.presence_service import PresenceService
+from apps.chat.services.read_service import ReadService
 from apps.study_groups.models import GroupMember, StudyGroup
 from apps.users.models import User
 
@@ -30,7 +33,6 @@ class ChatConsumer(AsyncWebsocketConsumer):  # type: ignore
         if user is None:
             await self.close(4001)
             return
-
         self.user = user
 
         # 멤버 검증
@@ -39,78 +41,76 @@ class ChatConsumer(AsyncWebsocketConsumer):  # type: ignore
             await self.close(4003)
             return
 
-        try:
-            await self.channel_layer.group_add(self.room_group_name, self.channel_name)
-            await self.accept()
-        except Exception:
-            await self.close(4500)
-            return
+        await self.channel_layer.group_add(self.room_group_name, self.channel_name)
+        await self.accept()
 
-        # 온라인 유저 등록
+        # 온라인 등록
         try:
-            redis = get_redis_connection("default")
-            redis.sadd(f"chat_online:{self.group_id}", self.user.id)
+            await PresenceService.add(self.group_id, self.user.id)  # type: ignore
         except Exception:
             pass
 
-        # presence
-        try:
-            members = await self.get_group_members()
-            await self.safe_send(
-                {
-                    "type": "presence",
-                    "members": members,
-                }
-            )
-        except Exception:
-            pass
+        # presence (Service 사용)
+        members = await self.get_presence()
+        await self.safe_send(
+            {
+                "type": "presence",
+                "members": members,
+            }
+        )
 
-        # 입장 broadcast
+        # user_join broadcast
         await self.channel_layer.group_send(
             self.room_group_name,
             {
                 "type": "user_join",
-                "user": {"id": self.user.id, "nickname": self.user.nickname},
+                "user": {
+                    "id": self.user.id,
+                    "nickname": self.user.nickname,
+                },
             },
         )
 
-        # 메시지 히스토리
-        history = await self.get_recent_messages(limit=100)
-        await self.safe_send({"type": "history", "messages": history})
+        # history
+        history = await self.get_history(limit=100)
+        await self.safe_send(
+            {
+                "type": "history",
+                "messages": history,
+            }
+        )
 
         # 읽음 처리
-        await self.mark_all_read(self.user.id, self.group_id)
+        await self.mark_all_read_service()
 
     async def disconnect(self, code: int) -> None:
         user: Optional[User] = getattr(self, "user", None)
 
-        # 온라인 제거
-        if user is not None:
+        if user:
             try:
-                redis = get_redis_connection("default")
-                redis.srem(f"chat_online:{self.group_id}", user.id)
+                await PresenceService.remove(self.group_id, user.id)  # type: ignore
             except Exception:
                 pass
 
-        # 그룹 제거
-        try:
-            await self.channel_layer.group_discard(self.room_group_name, self.channel_name)
-        except Exception:
-            pass
-
-        # 퇴장 broadcast
-        if user is not None:
             await self.channel_layer.group_send(
                 self.room_group_name,
                 {
                     "type": "user_leave",
-                    "user": {"id": user.id, "nickname": user.nickname},
+                    "user": {
+                        "id": user.id,
+                        "nickname": user.nickname,
+                    },
                 },
             )
 
+        await self.channel_layer.group_discard(
+            self.room_group_name,
+            self.channel_name,
+        )
+
     async def receive(self, text_data: str) -> None:
         try:
-            data: Dict[str, Any] = json.loads(text_data)
+            data = json.loads(text_data)
         except Exception:
             return
 
@@ -118,11 +118,7 @@ class ChatConsumer(AsyncWebsocketConsumer):  # type: ignore
         if not isinstance(content, str) or not content.strip():
             return
 
-        user: Optional[User] = getattr(self, "user", None)
-        if user is None:
-            return
-
-        msg = await self.save_message(content)
+        msg = await self.create_message(content)
 
         await self.channel_layer.group_send(
             self.room_group_name,
@@ -131,25 +127,25 @@ class ChatConsumer(AsyncWebsocketConsumer):  # type: ignore
                 "message": {
                     "id": msg.id,
                     "content": msg.content,
-                    "sender": {"id": user.id, "nickname": user.nickname},
+                    "sender": {
+                        "id": self.user.id,
+                        "nickname": self.user.nickname,
+                    },
                     "created_at": msg.created_at.isoformat(),
                 },
             },
         )
 
-        await self.update_last_read(msg)
+        await self.update_last_read_service(msg)
 
     async def chat_message(self, event: Dict[str, Any]) -> None:
-        message = event.get("message")
-        if not message:
-            return
-        await self.safe_send({"type": "message", **message})
+        await self.safe_send({"type": "message", **event["message"]})
 
     async def user_join(self, event: Dict[str, Any]) -> None:
-        await self.safe_send({"type": "user_join", "user": event.get("user")})
+        await self.safe_send({"type": "user_join", "user": event["user"]})
 
     async def user_leave(self, event: Dict[str, Any]) -> None:
-        await self.safe_send({"type": "user_leave", "user": event.get("user")})
+        await self.safe_send({"type": "user_leave", "user": event["user"]})
 
     async def safe_send(self, payload: Dict[str, Any]) -> None:
         try:
@@ -157,7 +153,7 @@ class ChatConsumer(AsyncWebsocketConsumer):  # type: ignore
         except Exception:
             pass
 
-    @database_sync_to_async  # type: ignore[misc]
+    @database_sync_to_async  # type: ignore
     def authenticate(self) -> Optional[User]:
         try:
             qs = self.scope["query_string"].decode()
@@ -171,77 +167,44 @@ class ChatConsumer(AsyncWebsocketConsumer):  # type: ignore
         except Exception:
             return None
 
-    @database_sync_to_async  # type: ignore[misc]
+    @database_sync_to_async  # type: ignore
     def check_member(self) -> bool:
-        return GroupMember.objects.filter(study_group_id=self.group_id, user_id=self.user.id).exists()
+        return GroupMember.objects.filter(
+            study_group_id=self.group_id,
+            user_id=self.user.id,
+        ).exists()
 
     @database_sync_to_async  # type: ignore[misc]
-    def get_group_members(self) -> List[Dict[str, Any]]:
-        members = GroupMember.objects.filter(study_group_id=self.group_id)
+    def get_presence(self) -> list[dict[str, Any]]:
+        return PresenceService.get_members(self.group_id)
 
-        redis = get_redis_connection("default")
-        online_ids = {int(uid) for uid in redis.smembers(f"chat_online:{self.group_id}")}
-
-        result = []
-        for m in members:
-            user = m.user_id
-            result.append(
-                {
-                    "id": user.id,
-                    "nickname": user.nickname,
-                    "is_online": user.id in online_ids,
-                    "is_host": m.is_leader,
-                }
-            )
-
-        return result
-
-    @database_sync_to_async  # type: ignore[misc]
-    def save_message(self, content: str) -> ChatMessage:
+    @database_sync_to_async  # type: ignore
+    def create_message(self, content: str) -> ChatMessage:
         group = StudyGroup.objects.get(id=self.group_id)
-        return ChatMessage.objects.create(
+        return MessageService.create_message(
             study_group=group,
-            sender=self.user,
+            user=self.user,
             content=content,
         )
 
-    @database_sync_to_async  # type: ignore[misc]
-    def update_last_read(self, msg: ChatMessage) -> None:
-        LastReadMessage.objects.update_or_create(
-            study_group_id=self.group_id,
+    @database_sync_to_async  # type: ignore
+    def get_history(self, limit: int) -> list[dict[str, Any]]:
+        return HistoryService.get_recent_messages(
+            group_id=self.group_id,
+            limit=limit,
+        )
+
+    @database_sync_to_async  # type: ignore
+    def update_last_read_service(self, msg: ChatMessage) -> None:
+        ReadService.update_last_read(
             user_id=self.user.id,
-            defaults={"message": msg},
+            group_id=self.group_id,
+            message=msg,
         )
 
-    @database_sync_to_async  # type: ignore[misc]
-    def get_recent_messages(self, limit: int) -> List[Dict[str, Any]]:
-        msgs = (
-            ChatMessage.objects.filter(study_group_id=self.group_id)
-            .exclude(sender__isnull=True)
-            .select_related("sender")
-            .order_by("-id")[:limit]
+    @database_sync_to_async  # type: ignore
+    def mark_all_read_service(self) -> None:
+        ReadService.mark_all_read(
+            user_id=self.user.id,
+            group_id=self.group_id,
         )
-
-        return [
-            {
-                "id": m.id,
-                "content": m.content,
-                "sender": {
-                    "id": m.sender_id,
-                    "nickname": m.sender.nickname,
-                },
-                "created_at": m.created_at.isoformat(),
-            }
-            for m in reversed(msgs)
-            if m.sender
-        ]
-
-    @database_sync_to_async  # type: ignore[misc]
-    def mark_all_read(self, user_id: int, group_id: int) -> None:
-        last_msg = ChatMessage.objects.filter(study_group_id=group_id).last()
-        if last_msg:
-            LastReadMessage.objects.update_or_create(
-                user_id=user_id,
-                study_group_id=group_id,
-                defaults={"message": last_msg},
-            )

--- a/apps/chat/services/history_service.py
+++ b/apps/chat/services/history_service.py
@@ -1,0 +1,28 @@
+from typing import Any, Dict, List
+
+from apps.chat.models import ChatMessage
+
+
+class HistoryService:
+    @staticmethod
+    def get_recent_messages(group_id: int, limit: int = 100) -> List[Dict[str, Any]]:
+        msgs = (
+            ChatMessage.objects.filter(study_group_id=group_id)
+            .exclude(sender__isnull=True)
+            .select_related("sender")
+            .order_by("-id")[:limit]
+        )
+
+        return [
+            {
+                "id": m.id,
+                "content": m.content,
+                "sender": {
+                    "id": m.sender_id,
+                    "nickname": m.sender.nickname,
+                },
+                "created_at": m.created_at.isoformat(),
+            }
+            for m in reversed(msgs)
+            if m.sender
+        ]

--- a/apps/chat/services/presence_service.py
+++ b/apps/chat/services/presence_service.py
@@ -1,0 +1,34 @@
+from typing import Any, Dict, List
+
+from django_redis import get_redis_connection  # type: ignore
+
+from apps.study_groups.models import GroupMember
+
+
+class PresenceService:
+    @staticmethod
+    def add(group_id: int, user_id: int) -> None:
+        redis = get_redis_connection("default")
+        redis.sadd(f"chat_online:{group_id}", user_id)
+
+    @staticmethod
+    def remove(group_id: int, user_id: int) -> None:
+        redis = get_redis_connection("default")
+        redis.srem(f"chat_online:{group_id}", user_id)
+
+    @staticmethod
+    def get_members(group_id: int) -> List[Dict[str, Any]]:
+        members = GroupMember.objects.filter(study_group_id=group_id).select_related("user_id")
+
+        redis = get_redis_connection("default")
+        online_ids = {int(uid) for uid in redis.smembers(f"chat_online:{group_id}")}
+
+        return [
+            {
+                "id": m.user_id.id,
+                "nickname": m.user_id.nickname,
+                "is_online": m.user_id.id in online_ids,
+                "is_host": m.is_leader,
+            }
+            for m in members
+        ]

--- a/apps/chat/services/read_service.py
+++ b/apps/chat/services/read_service.py
@@ -1,0 +1,33 @@
+from typing import Optional
+
+from apps.chat.models import ChatMessage, LastReadMessage
+
+
+class ReadService:
+    @staticmethod
+    def update_last_read(
+        *,
+        user_id: int,
+        group_id: int,
+        message: ChatMessage,
+    ) -> None:
+        LastReadMessage.objects.update_or_create(
+            user_id=user_id,
+            study_group_id=group_id,
+            defaults={"message": message},
+        )
+
+    @staticmethod
+    def mark_all_read(
+        *,
+        user_id: int,
+        group_id: int,
+    ) -> None:
+        last_msg: Optional[ChatMessage] = ChatMessage.objects.filter(study_group_id=group_id).order_by("-id").first()
+
+        if last_msg:
+            LastReadMessage.objects.update_or_create(
+                user_id=user_id,
+                study_group_id=group_id,
+                defaults={"message": last_msg},
+            )

--- a/config/asgi.py
+++ b/config/asgi.py
@@ -16,7 +16,7 @@ from channels.routing import (  # type: ignore[import-untyped]
 )
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.local")
 
 django_asgi_app = get_asgi_application()
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -24,6 +24,7 @@ DJANGO_APPS = [
 ]
 
 THIRD_PARTY_APPS = [
+    "channels",
     "rest_framework_simplejwt",
     "rest_framework",
     "corsheaders",


### PR DESCRIPTION
## ✅ PR 요약
채팅방 참여자 상태 응답 구조를 명확히 하고
websocket 메시지 전송 시 한글 JSON 깨짐 문제를 방지하기 위해
기존 consumer 로직 일부를 리팩토링함

## 📄 상세 내용
- [ ] safe_send JSON 직렬화 방식 개선

변경 전
기본 json.dumps 사용
한글 메시지 전송 시 escape 처리 발생

변경 후
한글 메시지를 그대로 전달하도록 개선

- [ ] 채팅방 멤버 presence 조회 로직 개선
GroupMember.user_id(FK) 기준으로 접근하도록 통일

- [ ] Django 설정 관련 보완
channels 앱을 INSTALLED_APPS에 추가

리뷰 반영 사항

WebSocket 연결 흐름(connect / disconnect / receive)은 Consumer에 유지
- 다음 로직을 Service 레이어로 분리
  - Presence 처리 (온라인 유저 관리)
  - 메시지 히스토리 조회
  - 읽음 처리 (LastReadMessage)
  
- 리팩토링 전과 동일하게
  - presence
  - history
  - user_join / user_leave
  - message
  타입의 WebSocket 이벤트는 그대로 유지

## 📸 스크린샷 (선택)
<img width="625" height="365" alt="image" src="https://github.com/user-attachments/assets/0990348b-e8e5-4f48-968a-f79e2216c7a2" />
<img width="619" height="364" alt="image" src="https://github.com/user-attachments/assets/036f96a9-1694-4e9e-8a2e-e13c193c1005" />


## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
