### PR TITLE
[Feature/withdrawals detail] 회원 탈퇴 내역 상세 조회

### DIFF
--- a/apps/users/serializers/admin_withdrawal_serializers.py
+++ b/apps/users/serializers/admin_withdrawal_serializers.py
@@ -56,6 +56,7 @@ class AdminWithdrawalUserDetailsSerializer(serializers.ModelSerializer[User]):
             "created_at",
         ]
 
+
 class AdminWithdrawalDetailSerializer(serializers.ModelSerializer[Withdrawal]):
     user = AdminWithdrawalUserDetailsSerializer(read_only=True)
 

--- a/apps/users/serializers/admin_withdrawal_serializers.py
+++ b/apps/users/serializers/admin_withdrawal_serializers.py
@@ -39,3 +39,33 @@ class AdminWithdrawalListItemSerializer(serializers.Serializer[Any]):
         if user is None or user.birthday is None:
             return None
         return user.birthday.isoformat()
+
+
+class AdminWithdrawalUserDetailsSerializer(serializers.ModelSerializer[User]):
+    class Meta:
+        model = User
+        fields = [
+            "id",
+            "email",
+            "nickname",
+            "name",
+            "gender",
+            "role",
+            "status",
+            "profile_img_url",
+            "created_at",
+        ]
+
+class AdminWithdrawalDetailSerializer(serializers.ModelSerializer[Withdrawal]):
+    user = AdminWithdrawalUserDetailsSerializer(read_only=True)
+
+    class Meta:
+        model = Withdrawal
+        fields = [
+            "id",
+            "user",
+            "reason",
+            "reason_detail",
+            "due_date",
+            "withdrawn_at",
+        ]

--- a/apps/users/services/admin_withdrawal_services.py
+++ b/apps/users/services/admin_withdrawal_services.py
@@ -1,6 +1,8 @@
-from typing import Optional
+from typing import Any, Optional, cast
 
 from django.db.models import Q
+from django.shortcuts import get_object_or_404
+from rest_framework.exceptions import NotFound
 
 from apps.core.pagination import OffsetPage, Pageable, offset_paginate_queryset
 from apps.users.models.withdrawal import Withdrawal
@@ -48,5 +50,14 @@ def get_admin_withdrawal_list(
     else:
         qs = qs.order_by("id")
 
-    page: OffsetPage[Withdrawal] = offset_paginate_queryset(qs, pageable)
-    return page
+    page = offset_paginate_queryset(cast(Any, qs), pageable)
+    return cast(OffsetPage[Withdrawal], page)
+
+
+def get_admin_withdrawal_detail(withdrawal_id: int) -> Withdrawal:
+    withdrawal = get_object_or_404(Withdrawal, pk=withdrawal_id)
+
+    if withdrawal.user is None:
+        raise NotFound(detail={"error_detail": "회원탈퇴 정보를 찾을 수 없습니다."})
+
+    return withdrawal

--- a/apps/users/services/admin_withdrawal_services.py
+++ b/apps/users/services/admin_withdrawal_services.py
@@ -1,7 +1,6 @@
 from typing import Any, Optional, cast
 
 from django.db.models import Q
-from django.shortcuts import get_object_or_404
 from rest_framework.exceptions import NotFound
 
 from apps.core.pagination import OffsetPage, Pageable, offset_paginate_queryset
@@ -55,9 +54,9 @@ def get_admin_withdrawal_list(
 
 
 def get_admin_withdrawal_detail(withdrawal_id: int) -> Withdrawal:
-    withdrawal = get_object_or_404(Withdrawal, pk=withdrawal_id)
+    withdrawal = Withdrawal.objects.select_related("user").filter(pk=withdrawal_id, user__isnull=False).first()
 
-    if withdrawal.user is None:
+    if withdrawal is None:
         raise NotFound(detail={"error_detail": "회원탈퇴 정보를 찾을 수 없습니다."})
 
     return withdrawal

--- a/apps/users/tests/test_admin_withdrawal_views.py
+++ b/apps/users/tests/test_admin_withdrawal_views.py
@@ -13,7 +13,7 @@ class AdminWithdrawalBaseTestCase(APITestCase):
             email="normal@test.com",
             password="testpass123",
             name="일반유저",
-            nickname="normal_user",
+            nickname="normal",
             phone_number="01000000001",
             gender="M",
         )
@@ -22,7 +22,7 @@ class AdminWithdrawalBaseTestCase(APITestCase):
             email="staff@test.com",
             password="testpass123",
             name="스태프유저",
-            nickname="staff_user",
+            nickname="staff",
             phone_number="01000000002",
             gender="F",
         )
@@ -33,7 +33,7 @@ class AdminWithdrawalBaseTestCase(APITestCase):
             email="admin@test.com",
             password="testpass123",
             name="관리자유저",
-            nickname="admin_user",
+            nickname="admin",
             phone_number="01000000003",
             gender="M",
         )

--- a/apps/users/tests/test_admin_withdrawal_views.py
+++ b/apps/users/tests/test_admin_withdrawal_views.py
@@ -1,0 +1,220 @@
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.users.models import User
+from apps.users.models.withdrawal import Withdrawal
+from apps.users.utils.reason_choices import WithdrawalReason
+
+
+class AdminWithdrawalBaseTestCase(APITestCase):
+    def setUp(self) -> None:
+        self.normal_user = User.objects.create_user(
+            email="normal@test.com",
+            password="testpass123",
+            name="일반유저",
+            nickname="normal_user",
+            phone_number="01000000001",
+            gender="M",
+        )
+
+        self.staff_user = User.objects.create_user(
+            email="staff@test.com",
+            password="testpass123",
+            name="스태프유저",
+            nickname="staff_user",
+            phone_number="01000000002",
+            gender="F",
+        )
+        self.staff_user.is_staff = True
+        self.staff_user.save()
+
+        self.admin_user = User.objects.create_user(
+            email="admin@test.com",
+            password="testpass123",
+            name="관리자유저",
+            nickname="admin_user",
+            phone_number="01000000003",
+            gender="M",
+        )
+        self.admin_user.is_staff = True
+        self.admin_user.is_superuser = True
+        self.admin_user.save()
+
+        self.withdrawal_1 = Withdrawal.objects.create(
+            user=self.normal_user,
+            reason=WithdrawalReason.NO_LONGER_NEEDED,
+        )
+        self.withdrawal_2 = Withdrawal.objects.create(
+            user=self.staff_user,
+            reason=WithdrawalReason.LACK_OF_INTEREST,
+        )
+
+        self.withdrawal_without_user = Withdrawal.objects.create(
+            user=None,
+            reason=WithdrawalReason.OTHER,
+        )
+
+        self.list_url = reverse("admin_withdrawal_list")
+
+
+class AdminWithdrawalListTests(AdminWithdrawalBaseTestCase):
+    def test_admin_withdrawal_list_unauthenticated_returns_401(self) -> None:
+        response = self.client.get(self.list_url)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn("error_detail", response.data)
+
+    def test_admin_withdrawal_list_forbidden_for_normal_user(self) -> None:
+        self.client.force_authenticate(user=self.normal_user)
+
+        response = self.client.get(self.list_url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn("error_detail", response.data)
+
+    def test_admin_withdrawal_list_success_for_staff_user(self) -> None:
+        self.client.force_authenticate(user=self.staff_user)
+
+        response = self.client.get(self.list_url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("count", response.data)
+        self.assertIn("next", response.data)
+        self.assertIn("previous", response.data)
+        self.assertIn("results", response.data)
+
+        self.assertEqual(response.data["count"], 3)
+        self.assertEqual(len(response.data["results"]), 3)
+
+        item = response.data["results"][0]
+        self.assertIn("id", item)
+        self.assertIn("email", item)
+        self.assertIn("name", item)
+        self.assertIn("role", item)
+        self.assertIn("birthday", item)
+        self.assertIn("reason", item)
+        self.assertIn("withdrawn_at", item)
+
+    def test_admin_withdrawal_list_search_by_email(self) -> None:
+        self.client.force_authenticate(user=self.staff_user)
+
+        response = self.client.get(self.list_url, {"search": "normal@test.com"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(
+            response.data["results"][0]["email"],
+            "normal@test.com",
+        )
+
+    def test_admin_withdrawal_list_filter_by_role_user(self) -> None:
+        self.client.force_authenticate(user=self.staff_user)
+
+        response = self.client.get(self.list_url, {"role": "user"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(
+            response.data["results"][0]["email"],
+            "normal@test.com",
+        )
+
+    def test_admin_withdrawal_list_filter_by_reason(self) -> None:
+        self.client.force_authenticate(user=self.staff_user)
+
+        response = self.client.get(
+            self.list_url,
+            {"reason": WithdrawalReason.LACK_OF_INTEREST},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(
+            response.data["results"][0]["reason"],
+            WithdrawalReason.LACK_OF_INTEREST,
+        )
+
+    def test_admin_withdrawal_list_sort_latest(self) -> None:
+        self.client.force_authenticate(user=self.staff_user)
+
+        response = self.client.get(self.list_url, {"sort": "latest"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("results", response.data)
+
+    def test_admin_withdrawal_list_sort_oldest(self) -> None:
+        self.client.force_authenticate(user=self.staff_user)
+
+        response = self.client.get(self.list_url, {"sort": "oldest"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("results", response.data)
+
+
+class AdminWithdrawalDetailTests(AdminWithdrawalBaseTestCase):
+    def test_admin_withdrawal_detail_unauthenticated_returns_401(self) -> None:
+        url = reverse(
+            "admin_withdrawal_detail",
+            args=[self.withdrawal_1.id],
+        )
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn("error_detail", response.data)
+
+    def test_admin_withdrawal_detail_forbidden_for_normal_user(self) -> None:
+        self.client.force_authenticate(user=self.normal_user)
+        url = reverse(
+            "admin_withdrawal_detail",
+            args=[self.withdrawal_1.id],
+        )
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn("error_detail", response.data)
+
+    def test_admin_withdrawal_detail_success_for_staff_user(self) -> None:
+        self.client.force_authenticate(user=self.staff_user)
+        url = reverse(
+            "admin_withdrawal_detail",
+            args=[self.withdrawal_1.id],
+        )
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.data
+        self.assertEqual(data["id"], self.withdrawal_1.id)
+        self.assertEqual(data["reason"], self.withdrawal_1.reason)
+        self.assertEqual(data["reason_detail"], self.withdrawal_1.reason_detail)
+        self.assertIn("user", data)
+        user_data = data["user"]
+        self.assertEqual(user_data["id"], self.normal_user.id)
+        self.assertEqual(user_data["email"], self.normal_user.email)
+        self.assertEqual(user_data["nickname"], self.normal_user.nickname)
+        self.assertEqual(user_data["name"], self.normal_user.name)
+
+    def test_admin_withdrawal_detail_not_found_returns_404_when_invalid_id(self) -> None:
+        self.client.force_authenticate(user=self.staff_user)
+        url = reverse("admin_withdrawal_detail", args=[999999])
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertIn("error_detail", response.data)
+
+    def test_admin_withdrawal_detail_not_found_when_user_is_none(self) -> None:
+        self.client.force_authenticate(user=self.staff_user)
+        url = reverse(
+            "admin_withdrawal_detail",
+            args=[self.withdrawal_without_user.id],
+        )
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertIn("error_detail", response.data)

--- a/apps/users/urls/admin.py
+++ b/apps/users/urls/admin.py
@@ -7,8 +7,8 @@ from apps.users.views.admin_account_views import (
     AdminAccountRoleUpdateSpec,
 )
 from apps.users.views.admin_withdrawal_views import (
-    AdminWithdrawalList,
     AdminWithdrawalDetail,
+    AdminWithdrawalList,
 )
 
 urlpatterns = [

--- a/apps/users/urls/admin.py
+++ b/apps/users/urls/admin.py
@@ -6,7 +6,6 @@ from apps.users.views.admin_account_views import (
     AdminAccountListSpec,
     AdminAccountRoleUpdateSpec,
 )
-
 from apps.users.views.admin_withdrawal_views import (
     AdminWithdrawalList,
 )
@@ -36,5 +35,5 @@ urlpatterns = [
         "/admin/withdrawal",
         AdminWithdrawalList.as_view(),
         name="admin_withdrawal_list",
-    )
+    ),
 ]

--- a/apps/users/urls/admin.py
+++ b/apps/users/urls/admin.py
@@ -8,6 +8,7 @@ from apps.users.views.admin_account_views import (
 )
 from apps.users.views.admin_withdrawal_views import (
     AdminWithdrawalList,
+    AdminWithdrawalDetail,
 )
 
 urlpatterns = [
@@ -32,8 +33,13 @@ urlpatterns = [
         name="admin_account_activate",
     ),
     path(
-        "/admin/withdrawal",
+        "/admin/withdrawals",
         AdminWithdrawalList.as_view(),
         name="admin_withdrawal_list",
+    ),
+    path(
+        "/admin/withdrawals/<int:withdrawal_id>",
+        AdminWithdrawalDetail.as_view(),
+        name="admin_withdrawal_detail",
     ),
 ]

--- a/apps/users/urls/admin.py
+++ b/apps/users/urls/admin.py
@@ -7,6 +7,10 @@ from apps.users.views.admin_account_views import (
     AdminAccountRoleUpdateSpec,
 )
 
+from apps.users.views.admin_withdrawal_views import (
+    AdminWithdrawalList,
+)
+
 urlpatterns = [
     path(
         "/admin/account",
@@ -28,4 +32,9 @@ urlpatterns = [
         AdminAccountActivateView.as_view(),
         name="admin_account_activate",
     ),
+    path(
+        "/admin/withdrawal",
+        AdminWithdrawalList.as_view(),
+        name="admin_withdrawal_list",
+    )
 ]

--- a/apps/users/views/admin_withdrawal_views.py
+++ b/apps/users/views/admin_withdrawal_views.py
@@ -5,7 +5,9 @@ from drf_spectacular.utils import (
     OpenApiExample,
     OpenApiParameter,
     extend_schema,
+    inline_serializer,
 )
+from rest_framework import serializers
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -13,16 +15,27 @@ from rest_framework.views import APIView
 
 from apps.core.pagination import Pageable
 from apps.users.serializers.admin_withdrawal_serializers import (
+    AdminWithdrawalDetailSerializer,
     AdminWithdrawalListItemSerializer,
 )
 from apps.users.services.admin_withdrawal_services import (
+    get_admin_withdrawal_detail,
     get_admin_withdrawal_list,
 )
 from apps.users.utils.permissions import StaffOrSuperUser
 from apps.users.utils.reason_choices import WithdrawalReason
 
+AdminWithdrawalSimpleErrorSerializer = inline_serializer(
+    name="AdminWithdrawalSimpleError",
+    fields={"error_detail": serializers.CharField()},
+)
+
 
 class AdminWithdrawalList(APIView):
+    """
+    어드민 페이지 회원 탈퇴 내역 목록 조회 APIView
+    """
+
     permission_classes = [StaffOrSuperUser]
     pagination_class = PageNumberPagination
 
@@ -73,8 +86,8 @@ class AdminWithdrawalList(APIView):
         ],
         responses={
             200: AdminWithdrawalListItemSerializer,
-            401: OpenApiTypes.OBJECT,
-            403: OpenApiTypes.OBJECT,
+            401: AdminWithdrawalSimpleErrorSerializer,
+            403: AdminWithdrawalSimpleErrorSerializer,
         },
         examples=[
             OpenApiExample(
@@ -151,3 +164,66 @@ class AdminWithdrawalList(APIView):
         }
 
         return Response(response_data)
+
+
+class AdminWithdrawalDetail(APIView):
+    """
+    어드민 페이지 회원 탈퇴 내역 상세 조회 API View
+    """
+
+    permission_classes = [StaffOrSuperUser]
+
+    @extend_schema(
+        tags=["Admin"],
+        summary="어드민 페이지 회원 탈퇴 상세 내역 조회",
+        description="스태프 및 관리자 권한을 가진 유저는 어드민 페이지 내에서 회원 탈퇴 상세 정보를 조회할 수 있습니다.",
+        responses={
+            200: AdminWithdrawalDetailSerializer,
+            401: AdminWithdrawalSimpleErrorSerializer,
+            403: AdminWithdrawalSimpleErrorSerializer,
+            404: AdminWithdrawalSimpleErrorSerializer,
+        },
+        examples=[
+            OpenApiExample(
+                name="Success Example",
+                value={
+                    "id": 1,
+                    "user": {
+                        "id": 1,
+                        "email": "user@example.com",
+                        "nickname": "test",
+                        "name": "홍길동",
+                        "gender": "M",
+                        "role": "user",
+                        "status": "active",
+                        "profile_img_url": "https://example.com/images/profiles/image.png",
+                        "created_at": "2025-10-30T14:01:57.505250+09:00",
+                    },
+                    "reason": "NO_LONGER_NEEDED",
+                    "reason_detail": "이제 안써요.",
+                    "due_date": "2025-11-01",
+                    "withdrawn_at": "2025-11-01T01:01:30+09:00",
+                },
+                status_codes=["200"],
+            ),
+            OpenApiExample(
+                name="Unauthorized Example",
+                value={"error_detail": "자격 인증 데이터가 제공되지 않았습니다."},
+                status_codes=["401"],
+            ),
+            OpenApiExample(
+                name="Forbidden Example",
+                value={"error_detail": "권한이 없습니다."},
+                status_codes=["403"],
+            ),
+            OpenApiExample(
+                name="Not Found Example",
+                value={"error_detail": "회원탈퇴 정보를 찾을 수 없습니다."},
+                status_codes=["404"],
+            ),
+        ],
+    )
+    def get(self, request: Request, withdrawal_id: int, *args: Any, **kwargs: Any) -> Response:
+        withdrawal = get_admin_withdrawal_detail(withdrawal_id=withdrawal_id)
+        serializer = AdminWithdrawalDetailSerializer(withdrawal)
+        return Response(serializer.data)


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 어드민 페이지 내에서 회원 탈퇴 내역 상세 조회 API 구현

## 📄 상세 내용
- [x] 회원 탈퇴 목록 조회 url 매핑
- [x] 회원 탈퇴 내역 상세 조회 serializer 생성
- [x] 회원 탈퇴 내역 상세 조회 service 생성
- [x] 회원 탈퇴 내역 상세 조회 views 생성
- [x] 회원 탈퇴 내역 상세 조회 url 매핑

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
