### PR TITLE
[Feat/user_social] 카카오 & 네이버 소셜 로그인 기능 추가

### DIFF
--- a/apps/users/services/kakao_login_services.py
+++ b/apps/users/services/kakao_login_services.py
@@ -1,0 +1,77 @@
+from typing import Any
+
+import requests
+from django.conf import settings
+from rest_framework.exceptions import ValidationError
+
+
+class KaKaoLoginServices(object):
+
+    def get_kakao_access_token(self, code: str) -> str:
+        url = "https://kauth.kakao.com/oauth/token"
+        headers = {"Content-Type": "application/x-www-form-urlencoded;charset=utf-8"}
+        data = {
+            "grant_type": "authorization_code",
+            "redirect_uri": settings.KAKAO_REDIRECT_URI,
+            "client_id": settings.KAKAO_CLIENT_ID,
+            "code": code,
+        }
+
+        response = requests.post(url, headers=headers, data=data)
+        token_data = response.json()
+
+        if response.status_code != 200 or "error" in token_data:
+            raise ValidationError(f"카카오 토큰 발급 실패: {token_data}")
+
+        return str(token_data.get("access_token"))
+
+    def get_kakao_user_info(self, token_id: str) -> dict[str, Any]:
+        url = "https://kapi.kakao.com/v2/user/me"
+        headers = {
+            "Authorization": f"Bearer {token_id}",
+            "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
+        }
+        response = requests.get(url, headers=headers)
+
+        if response.status_code != 200:
+            raise ValidationError("카카오 유저 정보 조회 실패")
+
+        response_json = response.json()
+
+        kakao_account = response_json.get("kakao_account", {})
+        profile = kakao_account.get("profile", {})
+
+        provider_id = str(response_json.get("id"))
+        email = kakao_account.get("email")
+        nickname = profile.get("nickname")
+        name = kakao_account.get("name")
+        profile_img_url = profile.get("profile_image_url")
+
+        birthyear = kakao_account.get("birthyear")
+        birthday = kakao_account.get("birthday")
+        final_birthday = f"{birthyear}-{birthday[:2]}-{birthday[2:]}"
+
+        gender = kakao_account.get("gender")
+        if gender == "male":
+            gender = gender.replace("male", "M")
+        elif gender == "female":
+            gender = gender.replace("female", "F")
+
+        phone_number = kakao_account.get("phone_number")
+        if phone_number:
+            clean_num = phone_number.replace(" ", "").replace("-", "")
+            if clean_num.startswith("+82"):
+                phone_number = clean_num.replace("+82", "0")
+            else:
+                phone_number = clean_num.replace("+", "")
+
+        return {
+            "provider_id": provider_id,
+            "email": email,
+            "nickname": nickname,
+            "gender": gender,
+            "birthday": final_birthday,
+            "profile_img_url": profile_img_url,
+            "name": name,
+            "phone_number": phone_number,
+        }

--- a/apps/users/services/naver_login_services.py
+++ b/apps/users/services/naver_login_services.py
@@ -1,0 +1,68 @@
+from typing import Any
+
+import requests
+from django.conf import settings
+from rest_framework.exceptions import ValidationError
+
+
+class NaverLoginService:
+
+    def get_naver_access_token(self, code: str, state: str) -> str:
+        url = "https://nid.naver.com/oauth2.0/token"
+        params = {
+            "client_id": settings.NAVER_CLIENT_ID,
+            "client_secret": settings.NAVER_CLIENT_SECRET,
+            "redirect_uri": settings.NAVER_REDIRECT_URI,
+            "grant_type": "authorization_code",
+            "state": state,
+            "code": code,
+        }
+
+        response = requests.get(url, params=params)
+        token_data = response.json()
+
+        if response.status_code != 200 or "error" in token_data:
+            raise ValidationError(f"네이버 토큰 발급 실패: {token_data}")
+
+        return str(token_data.get("access_token"))
+
+    def get_naver_user_info(self, token_id: str) -> dict[str, Any]:
+        url = "https://openapi.naver.com/v1/nid/me"
+        headers = {"Authorization": f"Bearer {token_id}"}
+
+        response = requests.get(url, headers=headers)
+        if not response.status_code == 200:
+            raise ValidationError("네이버 유저 정보 조회 실패")
+
+        response_json = response.json()
+
+        if not response_json.get("resultcode") == "00":
+            raise ValidationError("네이버 유저 정보 호출 실패")
+
+        user_data = response_json.get("response", {})
+
+        birthyear = user_data.get("birthyear")
+        birthday = user_data.get("birthday")
+        final_birthday = None
+        if birthyear and birthday:
+            final_birthday = f"{birthyear}-{birthday}"
+
+        gender = user_data.get("gender")
+        final_gender = None
+        if gender in ["M", "F"]:
+            final_gender = gender
+
+        phone_number = user_data.get("mobile")
+        if phone_number:
+            phone_number = phone_number.replace("-", "")
+
+        return {
+            "email": user_data.get("email"),
+            "nickname": user_data.get("nickname"),
+            "name": user_data.get("name"),
+            "phone_number": phone_number,
+            "birthday": final_birthday,
+            "gender": final_gender,
+            "profile_img_url": user_data.get("profile_image"),
+            "provider_id": user_data.get("id"),
+        }

--- a/apps/users/services/oauth_services.py
+++ b/apps/users/services/oauth_services.py
@@ -29,34 +29,37 @@ class SocialLoginService:
         if social_user:
             return social_user.user, False
 
+        existing_user = None
+
         # email 기반 기존 유저 연결
         if email_input:
             existing_user = User.objects.filter(email=email_input).first()
-            if existing_user:
-                SocialUser.objects.get_or_create(
-                    user=existing_user,
-                    provider=provider,
-                    provider_id=provider_id,
-                )
 
-                if not existing_user.nickname and nickname_input:
-                    existing_user.nickname = nickname_input
+        if not existing_user and phone_number_input:
+            existing_user = User.objects.filter(phone_number=phone_number_input).first()
 
-                if not existing_user.profile_img_url and profile_img_url_input:
-                    existing_user.profile_img_url = profile_img_url_input
+        if existing_user:
+            SocialUser.objects.get_or_create(
+                user=existing_user,
+                provider=provider,
+                provider_id=provider_id,
+            )
 
-                # gender, phone_number도 조건 체크 후 할당
-                if not existing_user.gender and gender_input:
-                    existing_user.gender = gender_input
-                if not existing_user.phone_number and phone_number_input:
-                    existing_user.phone_number = phone_number_input
-                if not existing_user.name and name_input:
-                    existing_user.name = name_input
-                if not existing_user.birthday and birthday_input:
-                    existing_user.birthday = birthday_input
+            if not existing_user.nickname and nickname_input:
+                existing_user.nickname = nickname_input
+            if not existing_user.profile_img_url and profile_img_url_input:
+                existing_user.profile_img_url = profile_img_url_input
+            if not existing_user.gender and gender_input:
+                existing_user.gender = gender_input
+            if not existing_user.phone_number and phone_number_input:
+                existing_user.phone_number = phone_number_input
+            if not existing_user.name and name_input:
+                existing_user.name = name_input
+            if not existing_user.birthday and birthday_input:
+                existing_user.birthday = birthday_input
 
-                existing_user.save()
-                return existing_user, False
+            existing_user.save()
+            return existing_user, False
 
         # 새 이메일 생성
         email = email_input or f"{provider}_{provider_id}@auto.com"
@@ -86,6 +89,8 @@ class SocialLoginService:
             user_data["phone_number"] = phone_number_input
 
         new_user = User.objects.create(**user_data)
+        new_user.set_unusable_password()
+        new_user.save()
 
         SocialUser.objects.create(
             user=new_user,

--- a/apps/users/services/oauth_services.py
+++ b/apps/users/services/oauth_services.py
@@ -16,6 +16,8 @@ class SocialLoginService:
         profile_img_url_input = user_info.get("profile_img_url")  # Optional[str]
         gender_input = user_info.get("gender")  # Optional[str]
         phone_number_input = user_info.get("phone_number")  # Optional[str]
+        name_input = user_info.get("name")
+        birthday_input = user_info.get("birthday")
 
         if provider not in ProviderChoices.values:
             raise ValueError("유효하지 않은 소셜 로그인 제공자입니다.")
@@ -31,36 +33,47 @@ class SocialLoginService:
         if email_input:
             existing_user = User.objects.filter(email=email_input).first()
             if existing_user:
-                SocialUser.objects.create(
+                SocialUser.objects.get_or_create(
                     user=existing_user,
                     provider=provider,
                     provider_id=provider_id,
                 )
 
-                if nickname_input and existing_user.nickname != nickname_input:
+                if not existing_user.nickname and nickname_input:
                     existing_user.nickname = nickname_input
 
-                if profile_img_url_input:
+                if not existing_user.profile_img_url and profile_img_url_input:
                     existing_user.profile_img_url = profile_img_url_input
 
                 # gender, phone_number도 조건 체크 후 할당
-                if gender_input is not None:
+                if not existing_user.gender and gender_input:
                     existing_user.gender = gender_input
-                if phone_number_input is not None:
+                if not existing_user.phone_number and phone_number_input:
                     existing_user.phone_number = phone_number_input
+                if not existing_user.name and name_input:
+                    existing_user.name = name_input
+                if not existing_user.birthday and birthday_input:
+                    existing_user.birthday = birthday_input
 
                 existing_user.save()
                 return existing_user, False
 
         # 새 이메일 생성
         email = email_input or f"{provider}_{provider_id}@auto.com"
-        nickname = nickname_input or self._generate_unique_nickname(provider)
+        final_nickname = nickname_input
+        if not final_nickname:
+            final_nickname = self._generate_unique_nickname(provider)
+        else:
+            # 소셜 닉네임이 이미 DB에 있다면? -> 뒤에 난수 붙여서 충돌 방지
+            while User.objects.filter(nickname=final_nickname).exists():
+                final_nickname = f"{nickname_input}_{uuid.uuid4().hex[:4]}"
 
         # 기본 user data
         user_data: Dict[str, Any] = {
             "email": email,
-            "nickname": nickname,
-            "name": nickname,
+            "nickname": final_nickname,
+            "name": name_input or final_nickname,
+            "birthday": birthday_input,
             "is_active": True,
             "profile_img_url": profile_img_url_input or "",
         }

--- a/apps/users/tests/test_social_login.py
+++ b/apps/users/tests/test_social_login.py
@@ -1,0 +1,87 @@
+from typing import Any
+from unittest.mock import patch
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+
+class SocialLoginTests(APITestCase):
+
+    def test_kakao_login_url(self) -> None:
+        try:
+            url = reverse("kakao_login")
+        except:
+            url = "/api/v1/accounts/social-login/kakao"
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("login_url", response.data)
+
+    def test_naver_login_url(self) -> None:
+        try:
+            url = reverse("naver_login")
+        except:
+            url = "/api/v1/accounts/social-login/naver"
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("login_url", response.data)
+
+    @patch("apps.users.services.kakao_login_services.KaKaoLoginServices.get_kakao_access_token")
+    @patch("apps.users.services.kakao_login_services.KaKaoLoginServices.get_kakao_user_info")
+    def test_kakao_callback_success(self, mock_get_user_info: Any, mock_get_token: Any) -> None:
+
+        mock_get_token.return_value = "fake_kakao_access_token"
+        mock_get_user_info.return_value = {
+            "provider_id": "1k2a3k4a5o",
+            "email": "kakaotest@kakao.com",
+            "nickname": "kakaonick",
+            "name": "테스트",
+            "gender": "M",
+            "birthday": "1990-01-01",
+            "profile_img_url": "http://kakao-image.com/profile.png",
+            "phone_number": "01012345678",
+        }
+
+        try:
+            url = reverse("kakao_callback")
+        except:
+            url = "/api/v1/accounts/social-login/kakao/callback"
+
+        response = self.client.get(url, {"code": "fake_code"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("access_token", response.data)
+        self.assertIn("refresh_token", response.data)
+        self.assertEqual(response.data["provider"], "kakao")
+        self.assertEqual(response.data["email"], "kakaotest@kakao.com")
+
+    @patch("apps.users.services.naver_login_services.NaverLoginService.get_naver_access_token")
+    @patch("apps.users.services.naver_login_services.NaverLoginService.get_naver_user_info")
+    def test_naver_callback_success(self, mock_get_user_info: Any, mock_get_token: Any) -> None:
+
+        mock_get_token.return_value = "fake_naver_access_token"
+        mock_get_user_info.return_value = {
+            "provider_id": "n1a2v3e4r",
+            "email": "navertest@naver.com",
+            "nickname": "navernick",
+            "name": "네이버버",
+            "gender": "F",
+            "birthday": "1995-12-25",
+            "profile_img_url": "http://naver-image.com/profile.jpg",
+            "phone_number": "01077778888",
+        }
+
+        try:
+            url = reverse("naver_callback")
+        except:
+            url = "/api/v1/accounts/social-login/naver/callback"
+
+        response = self.client.get(url, {"code": "random_code", "state": "random_state"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("access_token", response.data)
+        self.assertIn("refresh_token", response.data)
+        self.assertEqual(response.data["provider"], "naver")
+        self.assertEqual(response.data["email"], "navertest@naver.com")

--- a/apps/users/tests/test_social_login.py
+++ b/apps/users/tests/test_social_login.py
@@ -55,11 +55,9 @@ class SocialLoginTests(APITestCase):
 
         response = self.client.get(url, {"code": "fake_code"})
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn("access_token", response.data)
-        self.assertIn("refresh_token", response.data)
-        self.assertEqual(response.data["provider"], "kakao")
-        self.assertEqual(response.data["email"], "kakaotest@kakao.com")
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertIn("access_token", response.url)  # type: ignore
+        self.assertIn("refresh_token", response.cookies)
 
     @patch("apps.users.services.naver_login_services.NaverLoginService.get_naver_access_token")
     @patch("apps.users.services.naver_login_services.NaverLoginService.get_naver_user_info")
@@ -84,11 +82,9 @@ class SocialLoginTests(APITestCase):
 
         response = self.client.get(url, {"code": "random_code", "state": "random_state"})
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn("access_token", response.data)
-        self.assertIn("refresh_token", response.data)
-        self.assertEqual(response.data["provider"], "naver")
-        self.assertEqual(response.data["email"], "navertest@naver.com")
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertIn("access_token", response.url)  # type: ignore
+        self.assertIn("refresh_token", response.cookies)
 
 
 class OAuthServiceTests(TestCase):

--- a/apps/users/tests/test_social_login.py
+++ b/apps/users/tests/test_social_login.py
@@ -1,9 +1,13 @@
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+from django.test import TestCase
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
+
+from apps.users.services.kakao_login_services import KaKaoLoginServices
+from apps.users.services.naver_login_services import NaverLoginService
 
 
 class SocialLoginTests(APITestCase):
@@ -85,3 +89,82 @@ class SocialLoginTests(APITestCase):
         self.assertIn("refresh_token", response.data)
         self.assertEqual(response.data["provider"], "naver")
         self.assertEqual(response.data["email"], "navertest@naver.com")
+
+
+class OAuthServiceTests(TestCase):
+
+    @patch("requests.post")
+    def test_kakao_get_token_success(self, mock_post: Any) -> None:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"access_token": "fake_access_token"}
+        mock_post.return_value = mock_response
+
+        service = KaKaoLoginServices()
+        token = service.get_kakao_access_token("fake_code")
+
+        self.assertEqual(token, "fake_access_token")
+
+    @patch("requests.get")
+    def test_kakao_get_user_info_success(self, mock_get: Any) -> None:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "id": 123456789,
+            "kakao_account": {
+                "email": "test@kakao.com",
+                "birthyear": "1995",
+                "birthday": "1225",
+                "gender": "male",
+                "phone_number": "+82 10-1234-5678",
+                "profile": {"nickname": "kakaonick", "profile_image_url": "http://kakao-image.com/profile.png"},
+            },
+        }
+        mock_get.return_value = mock_response
+
+        service = KaKaoLoginServices()
+        user_info = service.get_kakao_user_info("fake_token")
+
+        self.assertEqual(user_info["email"], "test@kakao.com")
+        self.assertEqual(user_info["birthday"], "1995-12-25")
+        self.assertEqual(user_info["phone_number"], "01012345678")
+        self.assertEqual(user_info["gender"], "M")
+
+    @patch("requests.get")
+    def test_naver_get_token_success(self, mock_get: Any) -> None:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"access_token": "fake_naver_token"}
+        mock_get.return_value = mock_response
+
+        service = NaverLoginService()
+        token = service.get_naver_access_token("fake_code", "fake_state")
+
+        self.assertEqual(token, "fake_naver_token")
+
+    @patch("requests.get")
+    def test_naver_get_user_info_success(self, mock_get: Any) -> None:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "resultcode": "00",
+            "response": {
+                "id": "naver_id_123",
+                "email": "test@naver.com",
+                "nickname": "navernick",
+                "name": "네이버버",
+                "mobile": "010-9876-5432",
+                "birthyear": "1990",
+                "birthday": "01-01",
+                "gender": "F",
+                "profile_image": "http://naver-image.com/profile.jpg",
+            },
+        }
+        mock_get.return_value = mock_response
+
+        service = NaverLoginService()
+        user_info = service.get_naver_user_info("fake_token")
+        self.assertEqual(user_info["email"], "test@naver.com")
+        self.assertEqual(user_info["birthday"], "1990-01-01")
+        self.assertEqual(user_info["phone_number"], "01098765432")
+        self.assertEqual(user_info["gender"], "F")

--- a/apps/users/urls/account_urls.py
+++ b/apps/users/urls/account_urls.py
@@ -2,6 +2,12 @@ from django.urls import path
 
 from apps.users.views.email_auth_views import EmailSignUpVerifyView, EmailSignUpView
 from apps.users.views.token_views import LogoutView, TokenRefreshView
+from apps.users.views.oauth_views import (
+    KakaoCallBackView,
+    KakaoLoginView,
+    NaverCallBackView,
+    NaverLoginView,
+)
 from apps.users.views.user_account_views import (
     NicknameCheckView,
     UserAccountView,
@@ -20,4 +26,8 @@ urlpatterns = [
     path("accounts/login", LoginView.as_view(), name="login"),
     path("accounts/logout", LogoutView.as_view(), name="logout"),
     path("accounts/token/refresh", TokenRefreshView.as_view(), name="token-refresh"),
+    path("accounts/social-login/naver", NaverLoginView.as_view(), name="naver-login"),
+    path("accounts/social-login/naver/callback", NaverCallBackView.as_view(), name="naver-callback"),
+    path("accounts/social-login/kakao", KakaoLoginView.as_view(), name="kakao-login"),
+    path("accounts/social-login/kakao/callback", KakaoCallBackView.as_view(), name="kakao-callback"),
 ]

--- a/apps/users/urls/account_urls.py
+++ b/apps/users/urls/account_urls.py
@@ -1,13 +1,13 @@
 from django.urls import path
 
 from apps.users.views.email_auth_views import EmailSignUpVerifyView, EmailSignUpView
-from apps.users.views.token_views import LogoutView, TokenRefreshView
 from apps.users.views.oauth_views import (
     KakaoCallBackView,
     KakaoLoginView,
     NaverCallBackView,
     NaverLoginView,
 )
+from apps.users.views.token_views import LogoutView, TokenRefreshView
 from apps.users.views.user_account_views import (
     NicknameCheckView,
     UserAccountView,

--- a/apps/users/views/oauth_views.py
+++ b/apps/users/views/oauth_views.py
@@ -1,6 +1,11 @@
 import uuid
+from urllib.parse import urlencode
 
 from django.conf import settings
+from django.http import HttpResponse
+from django.shortcuts import redirect
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.permissions import AllowAny
 from rest_framework.request import Request
@@ -17,6 +22,13 @@ from apps.users.services.oauth_services import SocialLoginService
 class NaverLoginView(APIView):
     permission_classes = (AllowAny,)
 
+    @extend_schema(
+        tags=["Account"],
+        summary="네이버 로그인",
+        description="현재 네이버 로그인 된 유저의 상세 정보를 조회합니다.",
+        methods=["GET"],
+        responses={200: OpenApiTypes.OBJECT},
+    )
     def get(self, request: Request) -> Response:
 
         state = uuid.uuid4().hex
@@ -31,12 +43,21 @@ class NaverLoginView(APIView):
 
 
 class NaverCallBackView(APIView):
-    def get(self, request: Request) -> Response:
+    permission_classes = (AllowAny,)
+
+    @extend_schema(
+        tags=["Account"],
+        summary="네이버 로그인 콜백",
+        description="네이버 인증 코드를 받아 처리합니다.",
+        methods=["GET"],
+        responses={302: None},
+    )
+    def get(self, request: Request) -> HttpResponse:
         code = request.GET.get("code")
         state = request.GET.get("state")
 
         if not code or not state:
-            return Response({"error": "네이버 로그인 인증에 실패했습니다."}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({"error_detail": "네이버 로그인 인증에 실패했습니다."}, status=status.HTTP_400_BAD_REQUEST)
         try:
             naver_login = NaverLoginService()
             access_token = naver_login.get_naver_access_token(code, state)
@@ -47,10 +68,9 @@ class NaverCallBackView(APIView):
 
             token = RefreshToken.for_user(user)
 
-            return Response(
+            return_list = urlencode(
                 {
                     "access_token": str(token.access_token),
-                    "refresh_token": str(token),
                     "is_created": is_created,
                     "email": user.email,
                     "nickname": user.nickname,
@@ -60,17 +80,40 @@ class NaverCallBackView(APIView):
                     "gender": user.gender,
                     "profile_img_url": user.profile_img_url or "",
                     "provider": "naver",
-                },
-                status.HTTP_200_OK,
+                }
             )
 
-        except Exception as e:
-            return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+            base_url = getattr(settings, "FRONTEND_BASE_URL", "http://127.0.0.1:8000")
+            redirect_url = f"{base_url}/oauth/callback?{return_list}"
+
+            response = redirect(redirect_url)
+
+            response.set_cookie(
+                key="refresh_token",
+                value=str(token),
+                httponly=True,
+                secure=False,
+                samesite="Lax",
+                max_age=7 * 24 * 60 * 60,
+            )
+            return response
+
+        except:
+            return Response(
+                {"error_detail": "네이버 로그인 도중 오류가 발생했습니다."}, status=status.HTTP_400_BAD_REQUEST
+            )
 
 
 class KakaoLoginView(APIView):
     permission_classes = (AllowAny,)
 
+    @extend_schema(
+        tags=["Account"],
+        summary="카카오 로그인",
+        description="현재 카카오 로그인 된 유저의 상세 정보를 조회합니다.",
+        methods=["GET"],
+        responses={200: OpenApiTypes.OBJECT},
+    )
     def get(self, request: Request) -> Response:
         login_url = (
             f"https://kauth.kakao.com/oauth/authorize?response_type=code"
@@ -81,12 +124,20 @@ class KakaoLoginView(APIView):
 
 
 class KakaoCallBackView(APIView):
+    permission_classes = (AllowAny,)
 
-    def get(self, request: Request) -> Response:
+    @extend_schema(
+        tags=["Account"],
+        summary="카카오 로그인 콜백",
+        description="카카오 인증 코드를 받아 처리합니다.",
+        methods=["GET"],
+        responses={302: None},
+    )
+    def get(self, request: Request) -> HttpResponse:
         code = request.GET.get("code")
 
         if not code:
-            return Response({"error": "카카오 로그인 인증에 실패했습니다."}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({"error_detail": "카카오 로그인 인증에 실패했습니다."}, status=status.HTTP_400_BAD_REQUEST)
 
         try:
             kakao_login = KaKaoLoginServices()
@@ -100,10 +151,9 @@ class KakaoCallBackView(APIView):
 
             token = RefreshToken.for_user(user)
 
-            return Response(
+            return_list = urlencode(
                 {
                     "access_token": str(token.access_token),
-                    "refresh_token": str(token),
                     "is_created": is_created,
                     "email": user.email,
                     "name": user.name,
@@ -113,9 +163,24 @@ class KakaoCallBackView(APIView):
                     "gender": user.gender,
                     "profile_img_url": user.profile_img_url or "",
                     "provider": "kakao",
-                },
-                status.HTTP_200_OK,
+                }
             )
 
-        except Exception as e:
-            return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+            base_url = getattr(settings, "FRONTEND_BASE_URL", "http://127.0.0.1:8000")
+            redirect_url = f"{base_url}/oauth/callback?{return_list}"
+
+            response = redirect(redirect_url)
+            response.set_cookie(
+                key="refresh_token",
+                value=str(token),
+                httponly=True,
+                secure=False,
+                samesite="Lax",
+                max_age=7 * 24 * 60 * 60,
+            )
+            return response
+
+        except:
+            return Response(
+                {"error_detail": "카카오 로그인 도중 오류가 발생했습니다."}, status=status.HTTP_400_BAD_REQUEST
+            )

--- a/apps/users/views/oauth_views.py
+++ b/apps/users/views/oauth_views.py
@@ -1,0 +1,121 @@
+import uuid
+
+from django.conf import settings
+from rest_framework import status
+from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from apps.users.models.social_user import ProviderChoices
+from apps.users.services.kakao_login_services import KaKaoLoginServices
+from apps.users.services.naver_login_services import NaverLoginService
+from apps.users.services.oauth_services import SocialLoginService
+
+
+class NaverLoginView(APIView):
+    permission_classes = (AllowAny,)
+
+    def get(self, request: Request) -> Response:
+
+        state = uuid.uuid4().hex
+
+        login_url = (
+            f"https://nid.naver.com/oauth2.0/authorize?response_type=code"
+            f"&client_id={settings.NAVER_CLIENT_ID}"
+            f"&redirect_uri={settings.NAVER_REDIRECT_URI}"
+            f"&state={state}"
+        )
+        return Response({"login_url": login_url})
+
+
+class NaverCallBackView(APIView):
+    def get(self, request: Request) -> Response:
+        code = request.GET.get("code")
+        state = request.GET.get("state")
+
+        if not code or not state:
+            return Response({"error": "네이버 로그인 인증에 실패했습니다."}, status=status.HTTP_400_BAD_REQUEST)
+        try:
+            naver_login = NaverLoginService()
+            access_token = naver_login.get_naver_access_token(code, state)
+            user_info = naver_login.get_naver_user_info(access_token)
+
+            social_service = SocialLoginService()
+            user, is_created = social_service.login_or_signup(provider=ProviderChoices.NAVER, user_info=user_info)
+
+            token = RefreshToken.for_user(user)
+
+            return Response(
+                {
+                    "access_token": str(token.access_token),
+                    "refresh_token": str(token),
+                    "is_created": is_created,
+                    "email": user.email,
+                    "nickname": user.nickname,
+                    "name": user.name,
+                    "phone_number": user.phone_number,
+                    "birthday": user.birthday,
+                    "gender": user.gender,
+                    "profile_img_url": user.profile_img_url or "",
+                    "provider": "naver",
+                },
+                status.HTTP_200_OK,
+            )
+
+        except Exception as e:
+            return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+
+class KakaoLoginView(APIView):
+    permission_classes = (AllowAny,)
+
+    def get(self, request: Request) -> Response:
+        login_url = (
+            f"https://kauth.kakao.com/oauth/authorize?response_type=code"
+            f"&client_id={settings.KAKAO_CLIENT_ID}"
+            f"&redirect_uri={settings.KAKAO_REDIRECT_URI}"
+        )
+        return Response({"login_url": login_url})
+
+
+class KakaoCallBackView(APIView):
+
+    def get(self, request: Request) -> Response:
+        code = request.GET.get("code")
+
+        if not code:
+            return Response({"error": "카카오 로그인 인증에 실패했습니다."}, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            kakao_login = KaKaoLoginServices()
+            access_token = kakao_login.get_kakao_access_token(code)
+            user_info = kakao_login.get_kakao_user_info(access_token)
+            social_service = SocialLoginService()
+            user, is_created = social_service.login_or_signup(
+                provider=ProviderChoices.KAKAO,
+                user_info=user_info,
+            )
+
+            token = RefreshToken.for_user(user)
+
+            return Response(
+                {
+                    "access_token": str(token.access_token),
+                    "refresh_token": str(token),
+                    "is_created": is_created,
+                    "email": user.email,
+                    "name": user.name,
+                    "nickname": user.nickname,
+                    "phone_number": user.phone_number,
+                    "birthday": user.birthday,
+                    "gender": user.gender,
+                    "profile_img_url": user.profile_img_url or "",
+                    "provider": "kakao",
+                },
+                status.HTTP_200_OK,
+            )
+
+        except Exception as e:
+            return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -232,6 +232,9 @@ NAVER_CLIENT_ID = os.getenv("NAVER_CLIENT_ID")
 NAVER_CLIENT_SECRET = os.getenv("NAVER_CLIENT_SECRET")
 NAVER_REDIRECT_URI = os.getenv("NAVER_REDIRECT_URI")
 
+# SocialLogin Redirect
+FRONTEND_BASE_URL = os.getenv("FRONTEND_BASE_URL", "http://localhost:3000")
+
 # AWS S3 settings
 AWS_S3_REGION = os.getenv("AWS_S3_REGION", "")
 AWS_S3_ACCESS_KEY_ID = os.getenv("AWS_S3_ACCESS_KEY_ID", "")


### PR DESCRIPTION
## ✅ PR 요약
- 카카오 & 네이버 소셜 로그인 기능 추가

## 📄 상세 내용
- [x] 카카오 & 네이버 소셜 로그인 기능 추가
- [x] 회원 가입 양식에 맞춰 필드 값 제공
- [x] 하나의 서비스만 가입 가능 ( ex. 네이버 로그인 후 카카오 이용 불가 )
- [x] refresh token 사용으로 로직 변경
- [x] 200 X -> 302 O 환경 변수로 redirect 위치 조정
- [ ] 회원 탈퇴 시 소셜 철회 추가 예정

## 📸 스크린샷 (선택)
<img width="1920" height="1001" alt="kakao_social_success" src="https://github.com/user-attachments/assets/db8ae182-a682-4b75-bb83-87f77d2f7c6d" />
<img width="1920" height="994" alt="naver_social_success" src="https://github.com/user-attachments/assets/ae0c6ea3-dd4d-42ce-b3a5-7b98ed19716a" />

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
