### PR TITLE
[Feature/recruitment admin] recruitment_admin query 'tag'=> 'tags'로 변경 및 태그 5개로 제한

### DIFF
--- a/apps/recruitment/tests/test_recruitment_admin.py
+++ b/apps/recruitment/tests/test_recruitment_admin.py
@@ -262,7 +262,7 @@ class AdminRecruitmentAPITestCase(APITestCase):
 
     def test_filter_by_multiple_tags(self) -> None:
         """다중 태그 중 하나라도 포함하는 공고를 필터링합니다."""
-        tag_url = f"{self.list_url}?tag=Django,Python,미사용태그"
+        tag_url = f"{self.list_url}?tags=Django,Python,미사용태그"
         response = self.client.get(tag_url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/apps/recruitment/views/recruitment_admin_view.py
+++ b/apps/recruitment/views/recruitment_admin_view.py
@@ -64,7 +64,7 @@ class AdminRecruitmentListView(APIView):
                 description="마감 여부 (true | false)",
             ),
             OpenApiParameter(
-                "tag",
+                "tags",
                 OpenApiTypes.STR,
                 required=False,
                 description="공고 태그별 필터링(단일 태그명 또는 콤마로 구분된 다중 태그)",
@@ -94,7 +94,7 @@ class AdminRecruitmentListView(APIView):
                 qs = qs.filter(is_closed=False)
 
         # 공고 태그별 필터링(선택된 태그 중 하나라도 포함하는 공고 조회)
-        tag_param = request.query_params.get("tag")
+        tag_param = request.query_params.get("tags")
         if tag_param:
             tag_names = [t.strip() for t in tag_param.split(",") if t.strip()]
             if tag_names:

--- a/apps/recruitment/views/recruitment_tags_view.py
+++ b/apps/recruitment/views/recruitment_tags_view.py
@@ -39,7 +39,7 @@ class RecruitmentTagAPIView(APIView):
         except Recruitment.DoesNotExist:
             return Response({"error_detail": "해당 공고를 찾을 수 없습니다."}, status=status.HTTP_404_NOT_FOUND)
 
-        tags = [rt.tag for rt in recruitment.recruitment_tags.all()]
+        tags = [rt.tag for rt in recruitment.recruitment_tags.all()[:5]]
 
         serializer = TagSerializer(tags, many=True)
         return Response(


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: recruitment_admin query 'tag'=> 'tags'로 변경 및 태그 5개로 제한

## 📄 상세 내용
- [x] recruitment_admin query 'tag'=> 'tags'로 변경 
- [x] 태그 5개로 제한

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
