### PR TITLE
[Feat/S3] S3 삭제메서드 추가 / 기존 코드 리펙토링

### DIFF
--- a/apps/core/S3.py
+++ b/apps/core/S3.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import logging
 import uuid
-from functools import wraps
-from typing import Any, Callable, ClassVar, cast
+from functools import lru_cache, wraps
+from typing import Any, Callable
 
 import boto3
 from botocore.exceptions import (
@@ -13,7 +13,6 @@ from botocore.exceptions import (
     ParamValidationError,
 )
 from django.conf import settings
-from django.core.files.uploadedfile import UploadedFile
 from rest_framework.exceptions import APIException, ValidationError
 
 from apps.core.S3_constants import FileType, S3Constants
@@ -65,19 +64,16 @@ class S3Uploader:
     - 파일 업로드 (테스트 및 관리용)
     """
 
-    _s3_client: Any = None
-
-    @classmethod
-    def get_s3_client(cls) -> Any:
-        """S3 클라이언트 반환 (lazy initialization)"""
-        if cls._s3_client is None:
-            cls._s3_client = boto3.client(
-                "s3",
-                aws_access_key_id=getattr(settings, "AWS_S3_ACCESS_KEY_ID", None),
-                aws_secret_access_key=getattr(settings, "AWS_S3_SECRET_ACCESS_KEY", None),
-                region_name=getattr(settings, "AWS_S3_REGION", None),
-            )
-        return cls._s3_client
+    @staticmethod
+    @lru_cache(maxsize=1)
+    def get_s3_client() -> Any:
+        """S3 클라이언트 반환 (thread-safe lazy initialization)"""
+        return boto3.client(
+            "s3",
+            aws_access_key_id=getattr(settings, "AWS_S3_ACCESS_KEY_ID", None),
+            aws_secret_access_key=getattr(settings, "AWS_S3_SECRET_ACCESS_KEY", None),
+            region_name=getattr(settings, "AWS_S3_REGION", None),
+        )
 
     @classmethod
     def get_bucket_name(cls) -> str:
@@ -90,69 +86,6 @@ class S3Uploader:
         bucket = cls.get_bucket_name()
         region = getattr(settings, "AWS_S3_REGION", "")
         return f"https://{bucket}.s3.{region}.amazonaws.com/"
-
-    @classmethod
-    @handle_s3_errors("Presigned URL 생성")
-    def generate_presigned_urls(cls, prefix: str, files: list[dict[str, str]]) -> list[dict[str, Any]]:
-        """
-        Presigned URL 생성 (POST 방식, 복수)
-
-        Args:
-            prefix: S3 저장 경로 prefix
-            files: 파일 정보 리스트 (file_name, content_type 포함)
-
-        Returns:
-            list[dict]: Presigned URL 정보 리스트
-
-        Raises:
-            APIException: Presigned URL 생성 실패
-        """
-        presigned_data: list[dict[str, Any]] = []
-
-        if prefix and not prefix.endswith("/"):
-            prefix += "/"
-
-        for file in files:
-            file_name = file.get("file_name")
-            content_type = file.get("content_type")
-
-            if not file_name or not content_type:
-                raise ValidationError("file_name과 content_type은 필수입니다.")
-
-            S3FileValidator.validate_file_name(file_name)
-            ext = S3FileValidator.validate_file_extension(file_name)
-            S3FileValidator.validate_content_type(content_type)
-            S3FileValidator.validate_mime_match(ext, content_type)
-
-            key = f"{prefix}{uuid.uuid4()}_{file_name}"
-
-            presigned_post = cls.get_s3_client().generate_presigned_post(
-                Bucket=cls.get_bucket_name(),
-                Key=key,
-                Fields={"Content-Type": content_type},
-                Conditions=[
-                    {"Content-Type": content_type},
-                    [
-                        "content-length-range",
-                        S3Constants.MIN_FILE_SIZE_BYTES,
-                        S3Constants.MAX_FILE_SIZE_BYTES,
-                    ],
-                ],
-                ExpiresIn=S3Constants.PRESIGNED_URL_EXPIRE_SECONDS,
-            )
-
-            presigned_data.append(
-                {
-                    "file_name": file_name,
-                    "key": key,
-                    "url": presigned_post["url"],
-                    "fields": presigned_post["fields"],
-                    "file_url": cls.get_s3_base_url() + key,
-                    "expires_in": S3Constants.PRESIGNED_URL_EXPIRE_SECONDS,
-                }
-            )
-
-        return presigned_data
 
     @classmethod
     @handle_s3_errors("Presigned URL 생성")
@@ -191,15 +124,17 @@ class S3Uploader:
 
         S3FileValidator.validate_file_name(file_name)
 
-        S3FileValidator.validate_file_extension(file_name)
+        ext = S3FileValidator.validate_extension_match(file_name, file_ext)
 
-        S3FileValidator.validate_mime_match(file_ext, content_type)
+        S3FileValidator.validate_content_type(content_type)
+
+        S3FileValidator.validate_mime_match(ext, content_type)
 
         prefix = S3Constants.PATH_MAPPING.get(file_type_enum)
         if not prefix:
             raise ValidationError(f"경로를 찾을 수 없습니다: {file_type}")
 
-        key = f"{prefix}/{uuid.uuid4()}.{file_ext}"
+        key = f"{prefix}/{uuid.uuid4()}.{ext}"
 
         upload_url = cls.get_s3_client().generate_presigned_url(
             "put_object",
@@ -216,6 +151,37 @@ class S3Uploader:
             "file_url": f"{cls.get_s3_base_url()}{key}",
             "key": key,
             "headers": {"Content-Type": content_type},
+        }
+
+    @classmethod
+    @handle_s3_errors("파일 삭제")
+    def delete_file(cls, key: str) -> dict[str, Any]:
+        """
+        S3 파일 삭제 (단일)
+
+        Args:
+            key: S3 객체 키 (예: uploads/recruitments/images/uuid.png)
+
+        Returns:
+            dict: 삭제 결과
+                - message: 성공 메시지
+                - key: 삭제된 객체 키
+
+        Raises:
+            ValidationError: key가 비어있을 경우
+            APIException: S3 삭제 실패
+        """
+        if not key or not key.strip():
+            raise ValidationError("key는 필수입니다.")
+
+        cls.get_s3_client().delete_object(
+            Bucket=cls.get_bucket_name(),
+            Key=key,
+        )
+
+        return {
+            "message": "파일이 성공적으로 삭제되었습니다.",
+            "key": key,
         }
 
 

--- a/apps/core/S3.py
+++ b/apps/core/S3.py
@@ -168,11 +168,19 @@ class S3Uploader:
                 - key: 삭제된 객체 키
 
         Raises:
-            ValidationError: key가 비어있을 경우
+            ValidationError: key가 비어있거나 파일이 존재하지 않을 경우
             APIException: S3 삭제 실패
         """
         if not key or not key.strip():
             raise ValidationError("key는 필수입니다.")
+
+        try:
+            cls.get_s3_client().head_object(Bucket=cls.get_bucket_name(), Key=key)
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            if error_code == "404":
+                raise ValidationError(f"파일이 존재하지 않습니다: {key}")
+            raise
 
         cls.get_s3_client().delete_object(
             Bucket=cls.get_bucket_name(),

--- a/apps/core/S3_validators.py
+++ b/apps/core/S3_validators.py
@@ -36,6 +36,14 @@ class S3FileValidator:
             raise ValidationError("허용된 확장자(MIME)만 등록 가능합니다.")
 
     @staticmethod
+    def validate_extension_match(file_name: str, file_ext: str) -> str:
+        """파일명에서 추출한 확장자와 파라미터 확장자 일치 검증"""
+        ext = S3FileValidator.validate_file_extension(file_name)
+        if ext != file_ext.lower():
+            raise ValidationError(f"파일명의 확장자({ext})와 요청한 확장자({file_ext})가 일치하지 않습니다.")
+        return ext
+
+    @staticmethod
     def validate_mime_match(ext: str, content_type: Optional[str]) -> None:
         """MIME 타입과 확장자 일치 검증"""
         if not content_type:

--- a/apps/core/S3_view.py
+++ b/apps/core/S3_view.py
@@ -1,6 +1,6 @@
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import status
-from rest_framework.exceptions import APIException, ValidationError
+from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -114,4 +114,46 @@ class S3PresignedURLView(APIView):
             file_name=file_name,
             file_ext=file_ext,
         )
+        return Response(result, status=status.HTTP_200_OK)
+
+
+class S3FileDeleteView(APIView):
+    """S3 파일 삭제 View (단일)"""
+
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(
+        summary="S3 파일 삭제 (단일)",
+        description="S3 객체 키로 파일을 삭제합니다.",
+        request={
+            "application/json": {"type": "object", "properties": {"key": {"type": "string"}}, "required": ["key"]}
+        },
+        responses={
+            200: {
+                "description": "성공",
+                "content": {
+                    "application/json": {
+                        "example": {
+                            "message": "파일이 성공적으로 삭제되었습니다.",
+                            "key": "uploads/recruitment/images/uuid.png",
+                        }
+                    }
+                },
+            },
+            400: {
+                "description": "잘못된 요청",
+                "content": {"application/json": {"example": {"error_detail": "key는 필수입니다."}}},
+            },
+            401: {
+                "description": "인증 실패",
+                "content": {
+                    "application/json": {"example": {"error_detail": "자격 인증 데이터가 제공되지 않았습니다."}}
+                },
+            },
+        },
+        tags=["Common"],
+    )
+    def delete(self, request: Request) -> Response:
+        key = request.data.get("key", "")
+        result = s3_uploader.delete_file(key=key)
         return Response(result, status=status.HTTP_200_OK)

--- a/apps/core/S3_view.py
+++ b/apps/core/S3_view.py
@@ -142,7 +142,20 @@ class S3FileDeleteView(APIView):
             },
             400: {
                 "description": "잘못된 요청",
-                "content": {"application/json": {"example": {"error_detail": "key는 필수입니다."}}},
+                "content": {
+                    "application/json": {
+                        "examples": {
+                            "missing_key": {
+                                "summary": "key 누락",
+                                "value": {"error_detail": "key는 필수입니다."},
+                            },
+                            "file_not_found": {
+                                "summary": "파일이 존재하지 않음",
+                                "value": {"error_detail": "파일이 존재하지 않습니다: uploads/images/example.png"},
+                            },
+                        }
+                    }
+                },
             },
             401: {
                 "description": "인증 실패",

--- a/apps/core/tests/test_s3.py
+++ b/apps/core/tests/test_s3.py
@@ -345,6 +345,14 @@ class S3UploaderTest(S3MockTestBase):
             S3Uploader.delete_file(key="   ")
         self.assertIn("key는 필수입니다", str(ctx.exception.detail))
 
+    def test_delete_file_not_found(self) -> None:
+        """존재하지 않는 파일 삭제 시도"""
+        non_existent_key = "uploads/test/non-existent-file.png"
+
+        with self.assertRaises(ValidationError) as ctx:
+            S3Uploader.delete_file(key=non_existent_key)
+        self.assertIn("파일이 존재하지 않습니다", str(ctx.exception.detail))
+
     def test_delete_file_errors(self) -> None:
         """파일 삭제 에러 핸들링"""
         from unittest.mock import patch

--- a/apps/core/tests/test_s3.py
+++ b/apps/core/tests/test_s3.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import uuid
 from typing import Any, Optional
 
 import boto3
@@ -12,7 +11,6 @@ from botocore.exceptions import (
     ParamValidationError,
 )
 from django.conf import settings
-from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from django.utils import timezone
 from moto import mock_aws
@@ -23,11 +21,6 @@ from apps.core.S3 import S3Uploader
 from apps.core.S3_constants import FileType, S3Constants
 from apps.core.S3_validators import S3FileValidator
 from apps.users.models import User
-
-
-def _make_file(name: str, content_type: str, data: bytes = b"dummy") -> SimpleUploadedFile:
-    """테스트용 파일 객체 생성"""
-    return SimpleUploadedFile(name=name, content=data, content_type=content_type)
 
 
 class S3FileValidatorTest(TestCase):
@@ -101,6 +94,34 @@ class S3FileValidatorTest(TestCase):
         with self.assertRaises(ValidationError):
             S3FileValidator.validate_mime_match("pdf", "image/png")
 
+    def test_validate_extension_match_success(self) -> None:
+        """파일명과 확장자 일치 검증 성공"""
+        self.assertEqual(S3FileValidator.validate_extension_match("test.png", "png"), "png")
+        self.assertEqual(S3FileValidator.validate_extension_match("test.PNG", "png"), "png")
+        self.assertEqual(S3FileValidator.validate_extension_match("document.pdf", "pdf"), "pdf")
+        self.assertEqual(S3FileValidator.validate_extension_match("data.xlsx", "xlsx"), "xlsx")
+        self.assertEqual(S3FileValidator.validate_extension_match("file.hwp", "hwp"), "hwp")
+
+    def test_validate_extension_match_mismatch(self) -> None:
+        """파일명과 확장자 불일치"""
+        with self.assertRaises(ValidationError) as ctx:
+            S3FileValidator.validate_extension_match("test.png", "jpg")
+        self.assertIn("확장자", str(ctx.exception.detail))
+
+        with self.assertRaises(ValidationError):
+            S3FileValidator.validate_extension_match("document.pdf", "docx")
+
+        with self.assertRaises(ValidationError):
+            S3FileValidator.validate_extension_match("image.png", "gif")
+
+    def test_validate_extension_match_invalid_extension(self) -> None:
+        """허용되지 않은 확장자 (file_name에서)"""
+        with self.assertRaises(ValidationError):
+            S3FileValidator.validate_extension_match("malware.exe", "exe")
+
+        with self.assertRaises(ValidationError):
+            S3FileValidator.validate_extension_match("script.sh", "sh")
+
     def test_validate_file_size_success(self) -> None:
         S3FileValidator.validate_file_size(1024)
         S3FileValidator.validate_file_size(5 * 1024 * 1024)
@@ -171,7 +192,7 @@ class S3MockTestBase(TestCase):
         setattr(settings, "AWS_S3_ACCESS_KEY_ID", "test-key")
         setattr(settings, "AWS_S3_SECRET_ACCESS_KEY", "test-secret")
 
-        S3Uploader._s3_client = boto3.client("s3", region_name=self.region)
+        S3Uploader.get_s3_client.cache_clear()
         S3Uploader.get_s3_client().create_bucket(
             Bucket=self.bucket,
             CreateBucketConfiguration={"LocationConstraint": self.region},
@@ -181,7 +202,7 @@ class S3MockTestBase(TestCase):
         """S3 Mock 환경 정리"""
         if self._mock is not None:
             self._mock.stop()
-        S3Uploader._s3_client = None
+        S3Uploader.get_s3_client.cache_clear()
         logging.disable(logging.NOTSET)
 
 
@@ -189,8 +210,8 @@ class S3UploaderTest(S3MockTestBase):
     """S3Uploader 통합 테스트 (정상 케이스 + 에러 케이스)"""
 
     def test_lazy_initialization(self) -> None:
-        """lazy initialization 검증"""
-        S3Uploader._s3_client = None
+        """lazy initialization 및 캐싱 검증"""
+        S3Uploader.get_s3_client.cache_clear()
         client1 = S3Uploader.get_s3_client()
         client2 = S3Uploader.get_s3_client()
         self.assertIs(client1, client2)
@@ -241,23 +262,26 @@ class S3UploaderTest(S3MockTestBase):
                 file_ext="png",
             )
 
-    def test_generate_presigned_urls_multiple(self) -> None:
-        """복수 Presigned URL 생성 (POST 방식)"""
-        files = [
-            {"file_name": "image1.png", "content_type": "image/png"},
-            {"file_name": "image2.jpg", "content_type": "image/jpeg"},
-        ]
+    def test_generate_presigned_url_extension_mismatch(self) -> None:
+        """파일명과 file_ext 파라미터 불일치"""
+        with self.assertRaises(ValidationError) as ctx:
+            S3Uploader.generate_presigned_url(
+                file_type=FileType.USER_PROFILE_IMAGE.value,
+                content_type="image/jpeg",
+                file_name="test.png",
+                file_ext="jpg",
+            )
+        self.assertIn("확장자", str(ctx.exception.detail))
 
-        result = S3Uploader.generate_presigned_urls("uploads/test/", files)
-
-        self.assertEqual(len(result), 2)
-        for item in result:
-            self.assertIn("file_name", item)
-            self.assertIn("key", item)
-            self.assertIn("url", item)
-            self.assertIn("fields", item)
-            self.assertIn("file_url", item)
-            self.assertIn("expires_in", item)
+    def test_generate_presigned_url_security_exploit_attempt(self) -> None:
+        """보안: 악의적인 파일 업로드 시도"""
+        with self.assertRaises(ValidationError) as ctx:
+            S3Uploader.generate_presigned_url(
+                file_type=FileType.NOTE_ATTACHMENT.value,
+                content_type="application/pdf",
+                file_name="malware.exe",
+                file_ext="pdf",
+            )
 
     def test_presigned_url_errors(self) -> None:
         """Presigned URL 생성 에러 핸들링 검증"""
@@ -276,34 +300,71 @@ class S3UploaderTest(S3MockTestBase):
                 S3Uploader.generate_presigned_url(FileType.USER_PROFILE_IMAGE.value, "image/png", "test.png", "png")
             self.assertIn("Presigned URL 생성 중", str(ctx.exception.detail))
 
-    def test_presigned_urls_errors(self) -> None:
-        """복수 Presigned URL 생성 에러 핸들링"""
-        from unittest.mock import patch
-
-        files = [{"file_name": "test.png", "content_type": "image/png"}]
+        with patch.object(S3Uploader, "get_s3_client") as mock:
+            mock.return_value.generate_presigned_url.side_effect = ParamValidationError(report="Invalid param")
+            with self.assertRaises(APIException) as ctx:
+                S3Uploader.generate_presigned_url(FileType.USER_PROFILE_IMAGE.value, "image/png", "test.png", "png")
+            self.assertIn("잘못된 파라미터", str(ctx.exception.detail))
 
         with patch.object(S3Uploader, "get_s3_client") as mock:
-            mock.return_value.generate_presigned_post.side_effect = NoCredentialsError()
+            mock.return_value.generate_presigned_url.side_effect = BotoCoreError()
             with self.assertRaises(APIException) as ctx:
-                S3Uploader.generate_presigned_urls("test/", files)
+                S3Uploader.generate_presigned_url(FileType.USER_PROFILE_IMAGE.value, "image/png", "test.png", "png")
+            self.assertIn("S3 연결 중", str(ctx.exception.detail))
+
+        with patch.object(S3Uploader, "get_s3_client") as mock:
+            mock.return_value.generate_presigned_url.side_effect = Exception("Unexpected error")
+            with self.assertRaises(APIException) as ctx:
+                S3Uploader.generate_presigned_url(FileType.USER_PROFILE_IMAGE.value, "image/png", "test.png", "png")
+            self.assertIn("예상치 못한 오류", str(ctx.exception.detail))
+
+    def test_delete_file_success(self) -> None:
+        """단일 파일 삭제 성공"""
+        key = "uploads/test/test-file.png"
+        S3Uploader.get_s3_client().put_object(
+            Bucket=self.bucket,
+            Key=key,
+            Body=b"test content",
+        )
+
+        result = S3Uploader.delete_file(key=key)
+
+        self.assertEqual(result["message"], "파일이 성공적으로 삭제되었습니다.")
+        self.assertEqual(result["key"], key)
+
+        with self.assertRaises(ClientError):
+            S3Uploader.get_s3_client().head_object(Bucket=self.bucket, Key=key)
+
+    def test_delete_file_empty_key(self) -> None:
+        """빈 key로 삭제 시도"""
+        with self.assertRaises(ValidationError) as ctx:
+            S3Uploader.delete_file(key="")
+        self.assertIn("key는 필수입니다", str(ctx.exception.detail))
+
+        with self.assertRaises(ValidationError) as ctx:
+            S3Uploader.delete_file(key="   ")
+        self.assertIn("key는 필수입니다", str(ctx.exception.detail))
+
+    def test_delete_file_errors(self) -> None:
+        """파일 삭제 에러 핸들링"""
+        from unittest.mock import patch
+
+        with patch.object(S3Uploader, "get_s3_client") as mock:
+            mock.return_value.delete_object.side_effect = NoCredentialsError()
+            with self.assertRaises(APIException) as ctx:
+                S3Uploader.delete_file(key="test/file.png")
             self.assertIn("자격 증명", str(ctx.exception.detail))
 
         with patch.object(S3Uploader, "get_s3_client") as mock:
-            error: Any = {"Error": {"Code": "InvalidBucket", "Message": "Invalid Bucket"}}
-            mock.return_value.generate_presigned_post.side_effect = ClientError(error, "generate_presigned_post")
+            error: Any = {"Error": {"Code": "AccessDenied", "Message": "Access Denied"}}
+            mock.return_value.delete_object.side_effect = ClientError(error, "delete_object")
             with self.assertRaises(APIException) as ctx:
-                S3Uploader.generate_presigned_urls("test/", files)
-            self.assertIn("Presigned URL 생성 중", str(ctx.exception.detail))
-
-        with patch.object(S3Uploader, "get_s3_client") as mock:
-            mock.return_value.generate_presigned_post.side_effect = ParamValidationError(report="Invalid param")
-            with self.assertRaises(APIException) as ctx:
-                S3Uploader.generate_presigned_urls("test/", files)
-            self.assertIn("잘못된 파라미터", str(ctx.exception.detail))
+                S3Uploader.delete_file(key="test/file.png")
+            self.assertIn("파일 삭제 중", str(ctx.exception.detail))
 
 
-class S3PresignedURLViewTest(S3MockTestBase):
-    """S3 Presigned URL API 테스트"""
+class S3APITestBase(S3MockTestBase):
+    """S3 API 테스트를 위한 Base 클래스 (인증된 사용자 포함)"""
 
     def setUp(self) -> None:
         super().setUp()
@@ -318,6 +379,10 @@ class S3PresignedURLViewTest(S3MockTestBase):
             birthday=timezone.now().date(),
             is_active=True,
         )
+
+
+class S3PresignedURLViewTest(S3APITestBase):
+    """S3 Presigned URL API 테스트"""
 
     def test_presigned_url_unauthenticated(self) -> None:
         """인증 없이 요청"""
@@ -395,5 +460,86 @@ class S3PresignedURLViewTest(S3MockTestBase):
                 "file_name": "test.png",
                 "file_ext": "png",
             },
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_presigned_url_filename_ext_mismatch(self) -> None:
+        """파일명과 file_ext 파라미터 불일치"""
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(
+            "/api/v1/s3-presigned-url",
+            {
+                "type": FileType.USER_PROFILE_IMAGE.value,
+                "content_type": "image/jpeg",
+                "file_name": "profile.png",
+                "file_ext": "jpg",
+            },
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("확장자", str(response.data))
+
+    def test_presigned_url_security_attack(self) -> None:
+        """보안: 악의적인 파일 확장자 변조 시도"""
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(
+            "/api/v1/s3-presigned-url",
+            {
+                "type": FileType.NOTE_ATTACHMENT.value,
+                "content_type": "application/pdf",
+                "file_name": "script.exe",
+                "file_ext": "pdf",
+            },
+        )
+        self.assertEqual(response.status_code, 400)
+
+
+class S3FileDeleteViewTest(S3APITestBase):
+    """S3 파일 삭제 API 테스트 (단일)"""
+
+    def test_delete_file_unauthenticated(self) -> None:
+        """인증 없이 삭제 요청"""
+        response = self.client.delete(
+            "/api/v1/s3-file",
+            {"key": "uploads/test/file.png"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_delete_file_success(self) -> None:
+        """파일 삭제 성공"""
+        self.client.force_authenticate(user=self.user)
+        key = "uploads/test/test-file.png"
+        S3Uploader.get_s3_client().put_object(
+            Bucket=self.bucket,
+            Key=key,
+            Body=b"test content",
+        )
+
+        response = self.client.delete(
+            "/api/v1/s3-file",
+            {"key": key},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("message", response.data)
+        self.assertEqual(response.data["key"], key)
+
+    def test_delete_file_missing_key(self) -> None:
+        """key 파라미터 누락"""
+        self.client.force_authenticate(user=self.user)
+        response = self.client.delete(
+            "/api/v1/s3-file",
+            {},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_delete_file_empty_key(self) -> None:
+        """빈 key로 삭제 시도"""
+        self.client.force_authenticate(user=self.user)
+        response = self.client.delete(
+            "/api/v1/s3-file",
+            {"key": ""},
+            format="json",
         )
         self.assertEqual(response.status_code, 400)

--- a/apps/core/urls.py
+++ b/apps/core/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
 
-from .S3_view import S3PresignedURLView
+from .S3_view import S3FileDeleteView, S3PresignedURLView
 
 app_name = "core"
 
 urlpatterns = [
     path("s3-presigned-url", S3PresignedURLView.as_view(), name="s3-presigned-url"),
+    path("s3-file", S3FileDeleteView.as_view(), name="s3-file"),
 ]


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: S3 삭제 메서드 추가 / 기존 코드 리펙토링

## 📄 상세 내용
- [x] 1. Thread-safety 개선: S3 클라이언트에 @lru_cache 적용으로 멀티스레드 환경 안전성 확장
- [x] 2. API 단순화: 복수 건 Presigned URLs API 제거 API로 통일
- [x] 3. 테스트 개선: 복수 건 관련 테스트 7개 제거, 에러 핸들링 테스트 3개 추가 (ParamValidationError, BotoCoreError, Exception)
- [x] 4. 코드 정리: 불필요한 import 제거 (uuid, BotoCoreError, SimpleUploadedFile 등)
- [x] 5. 커버리지 향상
- [x] 6. 삭제 메서드 key값을 받아오는 형태

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
