### PR TITLE
[Feat/user social] 소셜로그인 명세서와 URL 타입에 맞게 수정

### DIFF
--- a/apps/users/tests/test_social_login.py
+++ b/apps/users/tests/test_social_login.py
@@ -19,8 +19,8 @@ class SocialLoginTests(APITestCase):
             url = "/api/v1/accounts/social-login/kakao"
 
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn("login_url", response.data)
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertIn("kauth.kakao.com", response.url)  # type: ignore
 
     def test_naver_login_url(self) -> None:
         try:
@@ -29,8 +29,8 @@ class SocialLoginTests(APITestCase):
             url = "/api/v1/accounts/social-login/naver"
 
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn("login_url", response.data)
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertIn("nid.naver.com", response.url)  # type: ignore
 
     @patch("apps.users.services.kakao_login_services.KaKaoLoginServices.get_kakao_access_token")
     @patch("apps.users.services.kakao_login_services.KaKaoLoginServices.get_kakao_user_info")

--- a/apps/users/views/oauth_views.py
+++ b/apps/users/views/oauth_views.py
@@ -84,7 +84,7 @@ class NaverCallBackView(APIView):
             )
 
             base_url = getattr(settings, "FRONTEND_BASE_URL", "http://127.0.0.1:8000")
-            redirect_url = f"{base_url}/oauth/callback?{return_list}"
+            redirect_url = f"{base_url}/social-callback?{return_list}"
 
             response = redirect(redirect_url)
 
@@ -167,7 +167,7 @@ class KakaoCallBackView(APIView):
             )
 
             base_url = getattr(settings, "FRONTEND_BASE_URL", "http://127.0.0.1:8000")
-            redirect_url = f"{base_url}/oauth/callback?{return_list}"
+            redirect_url = f"{base_url}/social-callback?{return_list}"
 
             response = redirect(redirect_url)
             response.set_cookie(

--- a/apps/users/views/oauth_views.py
+++ b/apps/users/views/oauth_views.py
@@ -29,7 +29,7 @@ class NaverLoginView(APIView):
         methods=["GET"],
         responses={200: OpenApiTypes.OBJECT},
     )
-    def get(self, request: Request) -> Response:
+    def get(self, request: Request) -> HttpResponse:
 
         state = uuid.uuid4().hex
 
@@ -39,7 +39,7 @@ class NaverLoginView(APIView):
             f"&redirect_uri={settings.NAVER_REDIRECT_URI}"
             f"&state={state}"
         )
-        return Response({"login_url": login_url})
+        return redirect(login_url)
 
 
 class NaverCallBackView(APIView):
@@ -48,7 +48,7 @@ class NaverCallBackView(APIView):
     @extend_schema(
         tags=["Account"],
         summary="네이버 로그인 콜백",
-        description="네이버 인증 코드를 받아 처리합니다.",
+        description="네이버 인증 코드를 받아 리다이렉트 시킵니다.",
         methods=["GET"],
         responses={302: None},
     )
@@ -83,7 +83,7 @@ class NaverCallBackView(APIView):
                 }
             )
 
-            base_url = getattr(settings, "FRONTEND_BASE_URL", "http://127.0.0.1:8000")
+            base_url = getattr(settings, "FRONTEND_BASE_URL", "http://localhost:5173")
             redirect_url = f"{base_url}/social-callback?{return_list}"
 
             response = redirect(redirect_url)
@@ -114,13 +114,13 @@ class KakaoLoginView(APIView):
         methods=["GET"],
         responses={200: OpenApiTypes.OBJECT},
     )
-    def get(self, request: Request) -> Response:
+    def get(self, request: Request) -> HttpResponse:
         login_url = (
             f"https://kauth.kakao.com/oauth/authorize?response_type=code"
             f"&client_id={settings.KAKAO_CLIENT_ID}"
             f"&redirect_uri={settings.KAKAO_REDIRECT_URI}"
         )
-        return Response({"login_url": login_url})
+        return redirect(login_url)
 
 
 class KakaoCallBackView(APIView):
@@ -129,7 +129,7 @@ class KakaoCallBackView(APIView):
     @extend_schema(
         tags=["Account"],
         summary="카카오 로그인 콜백",
-        description="카카오 인증 코드를 받아 처리합니다.",
+        description="카카오 인증 코드를 받아 리다이렉트 시킵니다.",
         methods=["GET"],
         responses={302: None},
     )
@@ -166,7 +166,7 @@ class KakaoCallBackView(APIView):
                 }
             )
 
-            base_url = getattr(settings, "FRONTEND_BASE_URL", "http://127.0.0.1:8000")
+            base_url = getattr(settings, "FRONTEND_BASE_URL", "http://localhost:5173")
             redirect_url = f"{base_url}/social-callback?{return_list}"
 
             response = redirect(redirect_url)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -233,7 +233,7 @@ NAVER_CLIENT_SECRET = os.getenv("NAVER_CLIENT_SECRET")
 NAVER_REDIRECT_URI = os.getenv("NAVER_REDIRECT_URI")
 
 # SocialLogin Redirect
-FRONTEND_BASE_URL = os.getenv("FRONTEND_BASE_URL", "http://localhost:3000")
+FRONTEND_BASE_URL = os.getenv("FRONTEND_BASE_URL", "http://localhost:5173")
 
 # AWS S3 settings
 AWS_S3_REGION = os.getenv("AWS_S3_REGION", "")


### PR DESCRIPTION
## ✅ PR 요약
- 소셜로그인 명세서와 URL 타입에 맞게 수정

## 📄 상세 내용
- [x] response -> redirect 반환 성격에 맞게 수정
- [x] 프론트엔드 포트 8000 -> 5173 수정

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
