### PR TITLE
[Feat/user_restore] 탈퇴 회원 복구 로직 작성

### DIFF
--- a/apps/users/serializers/login_serializer.py
+++ b/apps/users/serializers/login_serializer.py
@@ -23,5 +23,8 @@ class LoginSerializer(serializers.Serializer[Any]):
         if not check_password(password, user.password):
             raise serializers.ValidationError("비밀번호가 일치하지 않습니다")
 
+        if not user.is_active == True:
+            raise serializers.ValidationError("탈퇴 처리된 유저입니다. 회원 복구를 진행합니다.")
+
         data["user"] = user
         return data

--- a/apps/users/serializers/restore_serializers.py
+++ b/apps/users/serializers/restore_serializers.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict
+
+from django.contrib.auth import get_user_model
+from django.db import transaction
+from rest_framework import serializers
+
+from apps.users.utils.auth_code import AuthCodeCache
+
+
+class RestoreWithdrawalSerializer(serializers.Serializer[Any]):
+
+    email = serializers.EmailField(required=True)
+
+    def validate_email(self, value: str) -> str:
+        User = get_user_model()
+
+        try:
+            user = User.objects.get(email=value)
+        except User.DoesNotExist:
+            raise serializers.ValidationError({"error_detail": ["가입된 이메일이 아닙니다."]})
+
+        if user.is_active:
+            raise serializers.ValidationError({"error_detail": ["이미 활성화된 유저입니다."]})
+
+        return value
+
+
+class RestoreEmailCodeSerializer(serializers.Serializer[Any]):
+    email = serializers.EmailField(required=True)
+    code = serializers.CharField(required=True)
+
+    def validate(self, value: Dict[str, Any]) -> Dict[str, Any]:
+        email = value["email"]
+        code = value["code"]
+        key = f"email:restore:{email}"
+
+        if not AuthCodeCache.verify(key, code):
+            raise serializers.ValidationError(
+                {"error_detail": {"code": ["이메일 인증 실패 - 이메일 인증코드가 유효하지 않습니다."]}}
+            )
+
+        return value
+
+    def save(self, *args: Any, **kwargs: Any) -> Any:
+        User = get_user_model()
+        email = self.validated_data["email"]
+
+        try:
+            user = User.objects.get(email=email)
+        except User.DoesNotExist:
+            raise serializers.ValidationError({"error_detail": "해당 유저를 찾을 수 없습니다."})
+
+        with transaction.atomic():
+            user.is_active = True
+            user.save()
+
+            latest_withdrawal = user.withdrawals.order_by("-created_at").first()
+            if latest_withdrawal:
+                latest_withdrawal.delete()
+
+        return user

--- a/apps/users/tests/test_restore.py
+++ b/apps/users/tests/test_restore.py
@@ -1,0 +1,151 @@
+import random
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from django.contrib.auth import get_user_model
+from django.test import TransactionTestCase
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.users.models import Withdrawal
+from apps.users.serializers.restore_serializers import (
+    RestoreEmailCodeSerializer,
+    RestoreWithdrawalSerializer,
+)
+
+User = get_user_model()
+
+
+class RestoreSerializerCheck(TransactionTestCase):
+    def setUp(self) -> None:
+        uid = random.randint(1000, 9999)
+
+        self.inactive_user = User.objects.create(
+            email=f"testet{uid}@test01.com",
+            nickname=f"testet{uid}",
+            phone_number=f"0101234{uid}",
+            password="password",
+            is_active=False,
+        )
+
+        Withdrawal.objects.create(
+            user=self.inactive_user,
+            reason="TOO_DIFFICULT",
+            reason_detail="serializer test withdrawal",
+            due_date=timezone.now().date(),
+            withdrawn_at=timezone.now(),
+        )
+
+        self.active_user = User.objects.create(
+            email=f"tested{uid}@test02.com",
+            nickname=f"tested{uid}",
+            phone_number=f"0104321{uid}",
+            password="password",
+            is_active=True,
+        )
+
+    def test_restore_serializer_email_valid(self) -> None:
+        data = {"email": self.inactive_user.email}
+        serializer = RestoreWithdrawalSerializer(data=data)
+        self.assertTrue(serializer.is_valid())
+
+    def test_restore_serializer_email_not_found(self) -> None:
+        data = {"email": "unknown@test.com"}
+        serializer = RestoreWithdrawalSerializer(data=data)
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("email", serializer.errors)
+        self.assertIn("error_detail", serializer.errors["email"])
+        self.assertEqual(serializer.errors["email"]["error_detail"][0], "가입된 이메일이 아닙니다.")
+
+    def test_restore_serializer_already_active(self) -> None:
+        data = {"email": self.active_user.email}
+        serializer = RestoreWithdrawalSerializer(data=data)
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("email", serializer.errors)
+        self.assertIn("error_detail", serializer.errors["email"])
+        self.assertEqual(serializer.errors["email"]["error_detail"][0], "이미 활성화된 유저입니다.")
+
+    @patch("apps.users.utils.auth_code.AuthCodeCache.verify")
+    def test_restore_code_serializer_save(self, mock_verify: Any) -> None:
+        mock_verify.return_value = True
+
+        data = {"email": self.inactive_user.email, "code": "123456"}
+        serializer = RestoreEmailCodeSerializer(data=data)
+
+        self.assertTrue(serializer.is_valid())
+        user = serializer.save()
+        self.inactive_user.refresh_from_db()
+
+        self.assertTrue(user.is_active)
+        self.assertTrue(self.inactive_user.is_active)
+        self.assertEqual(Withdrawal.objects.filter(user=self.inactive_user).count(), 0)
+
+    @patch("apps.users.utils.auth_code.AuthCodeCache.verify")
+    def test_restore_code_serializer_invalid_code(self, mock_verify: Any) -> None:
+        mock_verify.return_value = False
+
+        data = {"email": self.inactive_user.email, "code": "000000"}
+        serializer = RestoreEmailCodeSerializer(data=data)
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("error_detail", serializer.errors)
+
+
+class RestoreViewCheck(APITestCase):
+    def setUp(self) -> None:
+        uid = random.randint(1000, 9999)
+
+        self.user = User.objects.create(
+            email=f"testts{uid}@test03.com",
+            nickname=f"testts{uid}",
+            phone_number=f"0100987{uid}",
+            password="password",
+            is_active=False,
+        )
+
+        Withdrawal.objects.create(
+            user=self.user,
+            reason="ETC",
+            reason_detail="view test withdrawal",
+            due_date=timezone.now().date(),
+            withdrawn_at=timezone.now(),
+        )
+
+    @patch("apps.users.utils.send_auth.SendAuth.send_restore_email")
+    def test_restore_send_email_view_success(self, mock_send_email: Any) -> None:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_send_email.return_value = mock_response
+
+        try:
+            url = reverse("restore-send-email")
+        except:
+            url = "/api/v1/accounts/restore/send-email"
+
+        data = {"email": self.user.email}
+        response = self.client.post(url, data=data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["detail"], "계정복구를 위한 이메일 인증 코드가 전송되었습니다.")
+
+    @patch("apps.users.utils.auth_code.AuthCodeCache.verify")
+    def test_restore_account_view_success(self, mock_verify: Any) -> None:
+        mock_verify.return_value = True
+
+        try:
+            url = reverse("restore-account")
+        except:
+            url = "/api/v1/accounts/restore"
+
+        data = {"email": self.user.email, "code": "123456"}
+        response = self.client.post(url, data=data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["detail"], "계정복구가 완료되었습니다.")
+
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.is_active)

--- a/apps/users/urls/account_urls.py
+++ b/apps/users/urls/account_urls.py
@@ -12,6 +12,7 @@ from apps.users.views.oauth_views import (
     NaverCallBackView,
     NaverLoginView,
 )
+from apps.users.views.restore_views import RestoreAccountView, RestoreSendEmailView
 from apps.users.views.token_views import LogoutView, TokenRefreshView
 from apps.users.views.user_account_views import (
     NicknameCheckView,
@@ -53,4 +54,6 @@ urlpatterns = [
         "accounts/find-password/verify-email", FindPasswordVerifyEmailView.as_view(), name="find-password-verify-email"
     ),
     path("accounts/find-email", FindEmailView.as_view(), name="find_email"),
+    path("accounts/restore", RestoreAccountView.as_view(), name="restore"),
+    path("accounts/restore/send-email", RestoreSendEmailView.as_view(), name="restore-send-email"),
 ]

--- a/apps/users/views/restore_views.py
+++ b/apps/users/views/restore_views.py
@@ -1,0 +1,89 @@
+from typing import Any
+
+from drf_spectacular.utils import OpenApiExample, OpenApiResponse, extend_schema
+from rest_framework import status
+from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.users.serializers.restore_serializers import (
+    RestoreEmailCodeSerializer,
+    RestoreWithdrawalSerializer,
+)
+from apps.users.utils.send_auth import SendAuth
+
+
+class RestoreSendEmailView(APIView):
+    permission_classes = (AllowAny,)
+
+    @extend_schema(
+        tags=["Account"],
+        summary="계정 복구 인증 이메일 발송",
+        description="입력한 이메일로 인증 코드를 발송합니다.",
+        request=RestoreWithdrawalSerializer,
+        methods=["POST"],
+        responses={
+            200: OpenApiResponse(
+                description="발송 성공",
+                examples=[
+                    OpenApiExample("발송 성공", value={"detail": "계정복구를 위한 이메일 인증 코드가 전송되었습니다."})
+                ],
+            ),
+            400: OpenApiResponse(
+                description="발송 실패",
+                examples=[
+                    OpenApiExample("발송 실패", value={"error_detail": {"email": ["가입된 이메일이 아닙니다."]}})
+                ],
+            ),
+        },
+    )
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        serializer = RestoreWithdrawalSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response({"error_detail": serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
+        email = serializer.validated_data["email"]
+        auth_response = SendAuth.send_restore_email(email)
+
+        if auth_response.status_code == 200:
+            return Response({"detail": "계정복구를 위한 이메일 인증 코드가 전송되었습니다."}, status=status.HTTP_200_OK)
+        return auth_response
+
+
+class RestoreAccountView(APIView):
+    permission_classes = (AllowAny,)
+
+    @extend_schema(
+        tags=["Account"],
+        summary="계정 복구 처리",
+        description="인증 코드를 확인하여 해당 계정을 복구합니다.",
+        request=RestoreEmailCodeSerializer,
+        methods=["POST"],
+        responses={
+            200: OpenApiResponse(
+                description="복구 성공",
+                examples=[OpenApiExample("성공 예시", value={"detail": "계정복구가 완료되었습니다."})],
+            ),
+            400: OpenApiResponse(
+                description="복구 실패",
+                examples=[
+                    OpenApiExample(
+                        "복구 실패",
+                        value={"error_detail": {"code": ["이메일 인증 실패 - 이메일 인증코드가 유효하지 않습니다."]}},
+                    )
+                ],
+            ),
+        },
+    )
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        serializer = RestoreEmailCodeSerializer(data=request.data)
+
+        if serializer.is_valid():
+            serializer.save()
+            return Response({"detail": "계정복구가 완료되었습니다."}, status=status.HTTP_200_OK)
+
+        errors = serializer.errors
+        if "error_detail" in errors:
+            return Response(errors, status=status.HTTP_400_BAD_REQUEST)
+        else:
+            return Response({"error_detail": errors}, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## ✅ PR 요약
- 탈퇴 회원 복구 로직 작성

## 📄 상세 내용
- [x] 로그인 조건에 is_active 제약 추가
- [x] 이메일 코드로 복구 확인

## 📸 스크린샷 (선택)
<img width="860" height="454" alt="accounts_restore_success" src="https://github.com/user-attachments/assets/f3fbf392-d334-4468-ae5c-22cb8fb04aaa" />
<img width="851" height="497" alt="accounts_restore_success_login" src="https://github.com/user-attachments/assets/b7d16f03-2b0f-4032-9e0e-88706954f072" />

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
