### PR TITLE
[Feat/study group calculate status] 스터디그룹 status 날짜에 맞게 계산하여 DB 업데이트

### DIFF
--- a/apps/study_groups/services/study_group_service.py
+++ b/apps/study_groups/services/study_group_service.py
@@ -1,17 +1,37 @@
+import logging
 from typing import Any, Optional
 
+from celery import shared_task
 from django.db import transaction
 from django.db.models import QuerySet
 from django.http import Http404
 from django.shortcuts import get_object_or_404
+from django.utils import timezone
 
 from apps.study_groups.models import GroupMember, StudyGroup, StudyLecture
 from apps.users.models import User as CustomUser
+
+logger = logging.getLogger(__name__)
 
 
 # 스터디 그룹 생성
 def create_study_group(user: CustomUser, validated_data: dict[str, Any]) -> StudyGroup:
     lectures_data = validated_data.pop("lectures", [])
+
+    # 오늘 날짜와 request 날짜 비교하여 status 자동 설정 로직
+    today = timezone.now()
+    start_at = validated_data.get("start_at")
+    end_at = validated_data.get("end_at")
+
+    if start_at and end_at:
+        # end_at 다음날부터 ENDED 처리 (end_at 당일까지는 ONGOING)
+        if end_at < today:
+            validated_data["status"] = StudyGroup.StudyGroupStatusChoices.ENDED
+        elif start_at <= today:
+            validated_data["status"] = StudyGroup.StudyGroupStatusChoices.ONGOING
+        else:
+            validated_data["status"] = StudyGroup.StudyGroupStatusChoices.PENDING
+
     study_group = StudyGroup.objects.create(**validated_data)
 
     # 강의 저장 (StudyLecture 생성)
@@ -184,3 +204,40 @@ def kick_member(*, group_id: int, current_user: CustomUser, target_user_id: int)
         raise ValueError("리더는 추방할 수 없습니다.")
 
     target_member.delete()
+
+
+# 스터디 그룹 상태 자동 갱신 (celery beat 사용해 작업 예약)
+@shared_task(name="study_groups.update_study_group_statuses")  # type: ignore[misc]
+def update_all_study_group_statuses() -> dict[str, int]:
+    try:
+        today = timezone.now()
+        updated_count = 0
+
+        # PENDING → ONGOING
+        pending_to_ongoing = StudyGroup.objects.filter(
+            status=StudyGroup.StudyGroupStatusChoices.PENDING,
+            start_at__lte=today,
+        )
+        for study_group in pending_to_ongoing:
+            if study_group.status == StudyGroup.StudyGroupStatusChoices.PENDING:
+                study_group.status = StudyGroup.StudyGroupStatusChoices.ONGOING
+                study_group.save(update_fields=["status"])
+                updated_count += 1
+
+        # ONGOING → ENDED (end_at 다음날부터 ENDED 처리)
+        ongoing_to_ended = StudyGroup.objects.filter(
+            status=StudyGroup.StudyGroupStatusChoices.ONGOING,
+            end_at__lt=today,
+        )
+        for study_group in ongoing_to_ended:
+            if study_group.status == StudyGroup.StudyGroupStatusChoices.ONGOING:
+                study_group.status = StudyGroup.StudyGroupStatusChoices.ENDED
+                study_group.save(update_fields=["status"])
+                updated_count += 1
+
+        result = {"updated_count": updated_count}
+        logger.info(f"스터디 그룹 상태 갱신 완료: {result['updated_count']}개 그룹이 갱신되었습니다.")
+        return result
+    except Exception as e:
+        logger.exception(f"스터디 그룹 상태 갱신 중 오류 발생: {e}")
+        raise

--- a/apps/study_groups/views/admin_study_groups_view.py
+++ b/apps/study_groups/views/admin_study_groups_view.py
@@ -16,6 +16,7 @@ from apps.study_groups.services.admin_study_group_services import (
     filter_study_groups_by_name,
     filter_study_groups_by_status,
     get_admin_study_group_queryset,
+    sort_study_groups,
 )
 
 
@@ -49,6 +50,15 @@ class AdminStudyGroupListView(APIView):
                 description="스터디 상태 필터",
                 enum=["PENDING", "ONGOING", "ENDED"],
             ),
+            # 정렬 선택용 파라미터 스키마 추가 (최신순/등록순/이름순서대로/이름역순으로)
+            # 디폴트값은 최신순
+            OpenApiParameter(
+                "sort",
+                OpenApiTypes.STR,
+                required=False,
+                description='정렬: "latest" | "oldest" | "name_asc" | "name_desc"',
+                enum=["latest", "oldest", "name_asc", "name_desc"],
+            ),
             OpenApiParameter("page", OpenApiTypes.INT, required=False),
             OpenApiParameter("page_size", OpenApiTypes.INT, required=False),
         ],
@@ -65,6 +75,10 @@ class AdminStudyGroupListView(APIView):
         status_param = request.query_params.get("status")
         if status_param and status_param in [choice[0] for choice in StudyGroup.StudyGroupStatusChoices.choices]:
             qs = filter_study_groups_by_status(qs, status_param)
+
+        # 정렬 파라미터
+        sort_param = request.query_params.get("sort")
+        qs = sort_study_groups(qs, sort_param)
 
         # 페이지네이션 파라미터 check/none 및 파라미터 반환 시 처리
         has_pagination_params = "page" in request.query_params or "page_size" in request.query_params


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 생성-DB 업데이트 사이 단계에서 날짜에 맞는 status 자동지정 / 자정마다 갱신 / sort 정렬 사용 

## 📄 상세 내용
- [x] 부등호를 활용해 날짜(오늘vs스터디시작/끝)에 따른 스터디그룹 상태정보 변경
- [x] celery의 @shared_task를 활용한 정기적 상태 갱신
- [x] sort 서비스 코드 사용하여 admin 스터디그룹 조회 시 필터링 정렬

## 📝 기타 참고 사항
추후 자정 status 정기갱신 로직도 부등호 사용하여 간단하게 수정 예정

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
