### PR TITLE
[fix/study-group-schedul-create] 스터디 그룹 생성 시 잘못된 참조 수정

### DIFF
--- a/apps/study_groups/services/schedule_services.py
+++ b/apps/study_groups/services/schedule_services.py
@@ -27,7 +27,7 @@ class ScheduleService:
 
     @staticmethod
     def create_schedule(*, validated_data: Dict[str, Any], group_id: int) -> GroupSchedule:
-        study_group = StudyGroup.objects.filter(id=group_id).first()
+        study_group = GroupMember.objects.filter(id=group_id).first()
         if study_group is None:
             raise ValueError("스터디 그룹 없음")
 


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 멤버 그룹이 아닌 스터디그룹 테이블을 참조하던 것을 수정

## 📄 상세 내용
- [ ] 조회하는 대상 테이블 변경
- [ ] 
## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
