### PR TITLE
Fix swagger visibility and debug environment variable

### DIFF
--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -4,7 +4,7 @@ import sentry_sdk
 
 from config.settings.base import *
 
-DEBUG = True
+DEBUG = os.getenv("DJANGO_DEBUG", "true") == "true"
 RAW_ALLOWED_HOSTS = os.getenv("DJANGO_ALLOWED_HOSTS", "")
 if not RAW_ALLOWED_HOSTS:
     raise ValueError("DJANGO_ALLOWED_HOSTS must be set")

--- a/config/urls.py
+++ b/config/urls.py
@@ -20,13 +20,14 @@ urlpatterns: list[URLPattern | URLResolver] = [
     path("api/v1/", include("apps.users.urls.account_urls")),
 ]
 
+if "drf_spectacular" in settings.INSTALLED_APPS:
+    urlpatterns += [
+        path("api/schema", SpectacularAPIView.as_view(), name="schema"),
+        path("api/schema/swagger-ui", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"),
+        path("api/schema/redoc", SpectacularRedocView.as_view(url_name="schema"), name="redoc"),
+    ]
+
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
     if "debug_toolbar" in settings.INSTALLED_APPS:
         urlpatterns += [path("__debug__/", include("debug_toolbar.urls"))]
-    if "drf_spectacular" in settings.INSTALLED_APPS:
-        urlpatterns += [
-            path("api/schema", SpectacularAPIView.as_view(), name="schema"),
-            path("api/schema/swagger-ui", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"),
-            path("api/schema/redoc", SpectacularRedocView.as_view(url_name="schema"), name="redoc"),
-        ]


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #123
- 작업 요약: Swagger 확인이 debug 상태와 상관없이 가능하도록 수정하고, debug 상태를 `os.getenv`로 가져오도록 코드 수정.

## 📄 상세 내용
- [x] debug와 상관없이 swagger를 확인할 수 있도록 수정.
- [x] debug 값을 `os.getenv`에서 가져오도록 변경.

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).