### PR TITLE
[Fix/study group change return userid to memberid] 시리얼라이저 id 반환값 변경

### DIFF
--- a/apps/study_groups/serializers/study_group.py
+++ b/apps/study_groups/serializers/study_group.py
@@ -217,7 +217,7 @@ class StudyGroupDetailSerializer(serializers.ModelSerializer[StudyGroup]):
                 if user is not None:
                     result.append(
                         {
-                            "id": user.id,
+                            "id": m.id,
                             "nickname": user.nickname,
                             "profile_img_url": user.profile_img_url,
                             "is_leader": m.is_leader,


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: get_members의 반환값에서 user.id를 m.id (멤버아이디)로 수정

## 📄 상세 내용
- [x] 스터디그룹 시리얼라이저 get_members의 반환값에서 user.id를 m.id (멤버아이디)로 수정

## 📝 기타 참고 사항
이슈 발생 시 롤백 예정

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
