### PR TITLE
Fix default values for unconfirmed Kakao and Naver fields

### DIFF
--- a/apps/users/services/kakao_login_services.py
+++ b/apps/users/services/kakao_login_services.py
@@ -72,7 +72,7 @@ class KaKaoLoginServices(object):
         name = kakao_account.get("name")
         profile_img_url = profile.get("profile_image_url")
 
-        birthyear = kakao_account.get("birthyear")
+        birthyear = kakao_account.get("birthyear", "2000")
         birthday = kakao_account.get("birthday")
         final_birthday = f"{birthyear}-{birthday[:2]}-{birthday[2:]}"
 

--- a/apps/users/services/naver_login_services.py
+++ b/apps/users/services/naver_login_services.py
@@ -66,7 +66,7 @@ class NaverLoginService:
 
         user_data = response_json.get("response", {})
 
-        birthyear = user_data.get("birthyear")
+        birthyear = user_data.get("birthyear", "2000")
         birthday = user_data.get("birthday")
         final_birthday = None
         if birthyear and birthday:


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #123
- 작업 요약: 카카오 및 네이버 미동의 항목의 기본값으로 생일 연도를 지정하는 문제를 수정했습니다.


## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).