### PR TITLE
[Feature]RecruitmentDetailSerializer 수정

### DIFF
--- a/apps/recruitment/serializers/recruitment_serializer.py
+++ b/apps/recruitment/serializers/recruitment_serializer.py
@@ -66,6 +66,7 @@ class RecruitmentListSerializer(serializers.ModelSerializer[Recruitment]):
 class RecruitmentDetailSerializer(serializers.ModelSerializer[Recruitment]):
     """구인공고 상세 조회"""
 
+    study_group_id = serializers.ReadOnlyField(source="study_group.id")
     bookmark_count = serializers.IntegerField(read_only=True, default=0)
     lectures = serializers.SerializerMethodField()
     tags = serializers.SerializerMethodField()
@@ -76,6 +77,7 @@ class RecruitmentDetailSerializer(serializers.ModelSerializer[Recruitment]):
         model = Recruitment
         fields = [
             "uuid",
+            "study_group_id",
             "title",
             "content",
             "estimated_fee",
@@ -92,6 +94,7 @@ class RecruitmentDetailSerializer(serializers.ModelSerializer[Recruitment]):
         ]
         read_only_fields = [
             "uuid",
+            "study_group_id",
             "views_count",
             "bookmark_count",
             "created_at",


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 공고 상세 조회 시 study_group_id 필드 추가

## 📄 상세 내용
- [ ] 공고 작성 후 수정 페이지에 진입했을 때, 기존 공고의 마크다운 데이터는 불러올 수 있으나 해당 공고가 속한 스터디 그룹의 ID가 응답에 포함되지 않는 문제

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
