### PR TITLE
[fix/user_login] 403 에러 반환을 위한 시리얼라이저 제약 삭제

### DIFF
--- a/apps/users/serializers/login_serializer.py
+++ b/apps/users/serializers/login_serializer.py
@@ -22,9 +22,5 @@ class LoginSerializer(serializers.Serializer[Any]):
 
         if not check_password(password, user.password):
             raise serializers.ValidationError("비밀번호가 일치하지 않습니다")
-
-        if not user.is_active == True:
-            raise serializers.ValidationError("탈퇴 처리된 유저입니다. 회원 복구를 진행합니다.")
-
         data["user"] = user
         return data


### PR DESCRIPTION
## ✅ PR 요약
- 403 에러 반환을 위한 시리얼라이저 제약 삭제

## 📄 상세 내용
- [x] view 에서 403 반환을 위해 시리얼라이저 is_active 제약 조건 삭제

## 📸 스크린샷 (선택)
<img width="1488" height="575" alt="image" src="https://github.com/user-attachments/assets/574a3729-9e67-43fa-ac30-4fb3935f0077" />

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
