### PR TITLE
[Feat/notification] 안 읽은 알람 개수를 내려주도록 변경

### DIFF
--- a/apps/notification/pagination.py
+++ b/apps/notification/pagination.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 
 class NotificationCursorPagination(CursorPagination):
     total_count: Optional[int] = None
+    unread_total: Optional[int] = None
     page_size = 10
     page_size_query_param = "page_size"
     cursor_query_param = "cursor"
@@ -20,6 +21,7 @@ class NotificationCursorPagination(CursorPagination):
                     ("next", self.get_next_link()),
                     ("previous", self.get_previous_link()),
                     ("total", getattr(self, "total_count", None)),
+                    ("unread_total", getattr(self, "unread_total", None)),
                     ("results", data),
                 ]
             )

--- a/apps/notification/pagination.py
+++ b/apps/notification/pagination.py
@@ -7,7 +7,7 @@ from rest_framework.response import Response
 
 class NotificationCursorPagination(CursorPagination):
     total_count: Optional[int] = None
-    unread_total: Optional[int] = None
+    unread_count: Optional[int] = None
     page_size = 10
     page_size_query_param = "page_size"
     cursor_query_param = "cursor"

--- a/apps/notification/pagination.py
+++ b/apps/notification/pagination.py
@@ -21,7 +21,7 @@ class NotificationCursorPagination(CursorPagination):
                     ("next", self.get_next_link()),
                     ("previous", self.get_previous_link()),
                     ("total", getattr(self, "total_count", None)),
-                    ("unread_total", getattr(self, "unread_total", None)),
+                    ("unread_total", getattr(self, "unread_count", None)),
                     ("results", data),
                 ]
             )

--- a/apps/notification/views/notification_views.py
+++ b/apps/notification/views/notification_views.py
@@ -53,6 +53,7 @@ class NotificationListAPIView(APIView):
         base_qs = Notification.objects.filter(user_id=authenticated_user.id)  # type: ignore
         # 전체 개수 먼저 확보 (필터 영향받지 않도록)
         total = base_qs.count()
+        unread_total = base_qs.filter(is_read=False).count()
 
         qs = base_qs
 
@@ -68,6 +69,7 @@ class NotificationListAPIView(APIView):
 
         # 페이지네이션 객체에 토탈 속성 심기
         paginator.total_count = total
+        paginator.unread_count = unread_total
 
         # 시리얼라이즈
         serializer = self.serializer_class(paginated_qs, many=True)


### PR DESCRIPTION
✨ : 프론트에서 요구하는대로 is read가 False인 알람의 숫자를 내려줌.

## ✅ PR 요약
- 관련 이슈 번호: #123
- 작업 요약: 어떤 작업을 했는지 간단하게 적어주세요.

## 📄 상세 내용
- [ ] ✨ : 프론트에서 요구하는대로 is read가 False인 알람의 숫자를 내려줌.
- [ ] 주요 변경 사항 2
- [ ] 주요 변경 사항 3

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
